### PR TITLE
Add SDK auto-download with mirror fallbacks and non-fatal failure handling

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,116 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+def localPropertiesFile = new File(rootDir, "local.properties")
+if (!localPropertiesFile.exists()) {
+    def sdkDir = System.getenv("ANDROID_SDK_ROOT") ?: System.getenv("ANDROID_HOME")
+    if (!sdkDir) {
+        def defaultSdkDir = new File(System.getProperty("user.home"), "Android/Sdk")
+        if (defaultSdkDir.exists()) {
+            sdkDir = defaultSdkDir.absolutePath
+        }
+    }
+    if (!sdkDir) {
+        def knownLocations = [
+                "/opt/android-sdk",
+                "/usr/local/android-sdk",
+                "/usr/lib/android-sdk"
+        ]
+        sdkDir = knownLocations.find { new File(it).exists() }
+    }
+    if (!sdkDir) {
+        def osName = System.getProperty("os.name").toLowerCase(Locale.ROOT)
+        def sdkRoot = new File(rootDir, "build/android-sdk")
+        def cmdlineToolsDir = new File(sdkRoot, "cmdline-tools/latest")
+        def sdkManager = new File(cmdlineToolsDir, "bin/sdkmanager")
+        try {
+            if (!sdkManager.exists()) {
+                sdkRoot.mkdirs()
+                def toolsBaseName = "commandlinetools-linux-11076708_latest.zip"
+                if (osName.contains("mac")) {
+                    toolsBaseName = "commandlinetools-mac-11076708_latest.zip"
+                } else if (osName.contains("win")) {
+                    toolsBaseName = "commandlinetools-win-11076708_latest.zip"
+                }
+                def toolsUrls = [
+                        "https://dl.google.com/android/repository/${toolsBaseName}",
+                        "https://mirrors.tuna.tsinghua.edu.cn/android/repository/${toolsBaseName}",
+                        "https://mirrors.cloud.tencent.com/android/repository/${toolsBaseName}"
+                ]
+                def zipFile = new File(sdkRoot, "commandlinetools.zip")
+                def downloaded = false
+                Exception downloadException = null
+                for (String toolsUrl : toolsUrls) {
+                    try {
+                        zipFile.withOutputStream { output ->
+                            new URL(toolsUrl).withInputStream { input ->
+                                output << input
+                            }
+                        }
+                        downloaded = true
+                        break
+                    } catch (Exception exception) {
+                        downloadException = exception
+                        zipFile.delete()
+                    }
+                }
+                if (!downloaded) {
+                    throw downloadException ?: new RuntimeException("Unable to download Android SDK command line tools")
+                }
+                def tempDir = new File(sdkRoot, "cmdline-tools-temp")
+                tempDir.deleteDir()
+                tempDir.mkdirs()
+                new java.util.zip.ZipInputStream(new FileInputStream(zipFile)).withCloseable { zipInput ->
+                    java.util.zip.ZipEntry entry
+                    while ((entry = zipInput.nextEntry) != null) {
+                        def target = new File(tempDir, entry.name)
+                        if (entry.isDirectory()) {
+                            target.mkdirs()
+                        } else {
+                            target.parentFile.mkdirs()
+                            target.withOutputStream { output -> output << zipInput }
+                        }
+                    }
+                }
+                def extractedTools = new File(tempDir, "cmdline-tools")
+                def extractedLatest = new File(tempDir, "cmdline-tools/latest")
+                if (extractedTools.exists() && !extractedLatest.exists()) {
+                    extractedTools.renameTo(extractedLatest)
+                }
+                cmdlineToolsDir.parentFile.mkdirs()
+                extractedLatest.renameTo(cmdlineToolsDir)
+                zipFile.delete()
+                tempDir.deleteDir()
+            }
+            if (sdkManager.exists()) {
+                def packages = [
+                        "platform-tools",
+                        "platforms;android-34",
+                        "build-tools;34.0.0"
+                ]
+                def installCommand = [sdkManager.absolutePath, "--sdk_root=${sdkRoot.absolutePath}"] + packages
+                def installProcess = new ProcessBuilder(installCommand)
+                        .inheritIO()
+                        .start()
+                if (installProcess.waitFor() == 0) {
+                    def licenseProcess = new ProcessBuilder(sdkManager.absolutePath, "--sdk_root=${sdkRoot.absolutePath}", "--licenses")
+                            .start()
+                    licenseProcess.outputStream.withWriter { writer ->
+                        10.times { writer.write("y\n") }
+                    }
+                    licenseProcess.waitFor()
+                    sdkDir = sdkRoot.absolutePath
+                }
+            }
+        } catch (Exception exception) {
+            println("Skipping SDK auto-download: ${exception.message}")
+        }
+    }
+    if (sdkDir) {
+        localPropertiesFile.text = "sdk.dir=${sdkDir.replace("\\\\", "\\\\\\\\")}\n"
+    }
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
### Motivation
- Ensure a missing Android SDK does not block initial Gradle evaluation by attempting to auto-detect or provision one and writing `local.properties` when found.
- Reduce developer/CI setup friction by provisioning the Android command-line tools and required packages when an SDK is not already present.
- Use regional mirrors as fallbacks to improve download reliability in restricted networks.
- Avoid crashing `settings.gradle` evaluation when network/downloads fail so Gradle can fail later with a clearer SDK-not-found message.

### Description
- Added SDK auto-detection and `local.properties` generation into `settings.gradle` after the `pluginManagement` block, checking `ANDROID_SDK_ROOT`, `ANDROID_HOME`, common system paths, and `~/Android/Sdk`.
- If no SDK is found, attempts to download Android command-line tools into `build/android-sdk` and install `platform-tools`, `platforms;android-34`, and `build-tools;34.0.0` via `sdkmanager`.
- Added multiple download URLs (Google plus regional mirrors) and wrapped the entire auto-download/install flow in a `try/catch` so failures are non-fatal and produce a diagnostic message.
- When provisioning succeeds sets `local.properties` with `sdk.dir` (escaping Windows backslashes) so builds can proceed.

### Testing
- Ran `./gradlew assembleDebug` before the changes which previously failed due to the `pluginManagement {}` ordering error. (Fixed by moving SDK logic after `pluginManagement`.)
- Ran `./gradlew assembleDebug` after the changes which attempted auto-download but failed due to a network proxy returning HTTP 403, producing the message that the SDK location was not found; the auto-download path prints a non-fatal diagnostic when blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbac7d2ac833094d6223214665865)