### PR TITLE
Reload substances on language change

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SubstanceRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SubstanceRepository.kt
@@ -44,10 +44,19 @@ class SubstanceRepository @Inject constructor(
     }
 
     private var substanceFile: SubstanceFile
+    private var loadedLanguageKey: String
 
     init {
         val languageKey = I18n.getPreferredLanguageKey() ?: I18n.getCurrentLanguageKey()
         substanceFile = loadSubstanceFile(languageKey)
+        loadedLanguageKey = languageKey
+    }
+
+    private fun ensureLanguageLoaded() {
+        val languageKey = I18n.getPreferredLanguageKey() ?: I18n.getCurrentLanguageKey()
+        if (languageKey == loadedLanguageKey) return
+        substanceFile = loadSubstanceFile(languageKey)
+        loadedLanguageKey = languageKey
     }
 
     private fun loadSubstanceFile(languageKey: String): SubstanceFile {
@@ -143,10 +152,12 @@ class SubstanceRepository @Inject constructor(
     }
 
     override fun getAllSubstances(): List<Substance> {
+        ensureLanguageLoaded()
         return substanceFile.substances
     }
 
     override fun getAllSubstancesWithCategories(): List<SubstanceWithCategories> {
+        ensureLanguageLoaded()
         return substanceFile.substances.map { substance ->
             SubstanceWithCategories(
                 substance = substance,
@@ -158,18 +169,22 @@ class SubstanceRepository @Inject constructor(
     }
 
     override fun getAllCategories(): List<Category> {
+        ensureLanguageLoaded()
         return substanceFile.categories
     }
 
     override fun getSubstance(substanceName: String): Substance? {
+        ensureLanguageLoaded()
         return substanceFile.substancesMap[substanceName]
     }
 
     override fun getCategory(categoryName: String): Category? {
+        ensureLanguageLoaded()
         return substanceFile.categories.firstOrNull { it.name == categoryName }
     }
 
     override fun getSubstanceWithCategories(substanceName: String): SubstanceWithCategories? {
+        ensureLanguageLoaded()
         val substance =
             substanceFile.substances.firstOrNull { it.name == substanceName } ?: return null
         return SubstanceWithCategories(


### PR DESCRIPTION
### Motivation
- The app must show localized substance data when the user changes the language preference, so cached substances/categories need to refresh when the language changes.
- Avoid stale data being returned from the `SubstanceRepository` after `I18n.setPreferredLanguageKey` is called.

### Description
- Added a `loadedLanguageKey` field and initialized it in `SubstanceRepository` to track which language is currently loaded.
- Implemented `ensureLanguageLoaded()` which checks `I18n.getPreferredLanguageKey()`/`I18n.getCurrentLanguageKey()` and reloads via `loadSubstanceFile` if the language changed.
- Call `ensureLanguageLoaded()` at the start of public accessors (`getAllSubstances`, `getAllCategories`, `getSubstance`, `getCategory`, `getAllSubstancesWithCategories`, `getSubstanceWithCategories`).
- Kept existing merge/parse logic intact and only added lazy refresh behavior when the preferred language changes.

### Testing
- No automated tests were executed as part of this change.
- No test failures were reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69613d71a6588330a8a68d4fb6c8c5bd)