### PR TITLE
I18n: move Settings, Custom Units and Substance Colors UI strings to i18n

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/search/AddIngestionSearchScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/search/AddIngestionSearchScreen.kt
@@ -69,6 +69,7 @@ import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
 import com.isaakhanimann.journal.data.room.experiences.entities.CustomSubstance
 import com.isaakhanimann.journal.data.room.experiences.entities.CustomUnit
 import com.isaakhanimann.journal.data.substances.AdministrationRoute
+import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.search.suggestion.SuggestionRow
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.search.suggestion.models.SubstanceRouteSuggestion
 import com.isaakhanimann.journal.ui.tabs.search.SubstanceModel
@@ -224,7 +225,7 @@ fun AddIngestionSearchScreen(
                 }
                 if (filteredCustomUnits.isNotEmpty()) {
                     stickyHeader {
-                        SectionHeader(title = "Custom units")
+                        SectionHeader(title = i18n("custom_units_title"))
                     }
                 }
                 itemsIndexed(filteredCustomUnits) { index, customUnit ->

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -158,7 +158,7 @@ fun SettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Settings") }
+                title = { Text(i18n("settings")) }
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -170,24 +170,24 @@ fun SettingsScreen(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {
-            CardWithTitle(title = "UI", innerPaddingHorizontal = 0.dp) {
+            CardWithTitle(title = i18n("settings_section_ui"), innerPaddingHorizontal = 0.dp) {
                 SettingsButton(
                     imageVector = Icons.Outlined.Medication,
-                    text = "Custom units"
+                    text = i18n("custom_units_title")
                 ) {
                     navigateToCustomUnits()
                 }
                 HorizontalDivider()
                 SettingsButton(
                     imageVector = Icons.Outlined.Palette,
-                    text = "Substance colors"
+                    text = i18n("substance_colors_title")
                 ) {
                     navigateToSubstanceColors()
                 }
                 HorizontalDivider()
                 SettingsButton(
                     imageVector = Icons.Outlined.WarningAmber,
-                    text = "Interaction settings"
+                    text = i18n("settings_interaction_settings")
                 ) {
                     navigateToComboSettings()
                 }
@@ -222,7 +222,7 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = "Hide dosage dots")
+                    Text(text = i18n("settings_hide_dosage_dots"))
                     Switch(
                         checked = areDosageDotsHidden,
                         onCheckedChange = saveDosageDotsAreHidden)

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
 import com.isaakhanimann.journal.data.room.experiences.entities.SubstanceCompanion
+import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.time.ColorPicker
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 
@@ -87,7 +88,7 @@ fun SubstanceColorsScreenContent(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("Substance colors") })
+            TopAppBar(title = { Text(i18n("substance_colors_title")) })
         },
     ) { padding ->
         LazyColumn(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/CustomUnitsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/CustomUnitsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.isaakhanimann.journal.data.room.experiences.entities.CustomUnit
+import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.tabs.stats.EmptyScreenDisclaimer
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
@@ -90,10 +91,10 @@ fun CustomUnitsScreenContent(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Custom units") },
+                title = { Text(i18n("custom_units_title")) },
                 actions = {
                     IconButton(onClick = navigateToCustomUnitArchive) {
-                        Icon(Icons.Default.Inventory, contentDescription = "Go to archive")
+                        Icon(Icons.Default.Inventory, contentDescription = i18n("custom_units_go_to_archive"))
                     }
                 })
         },
@@ -101,10 +102,10 @@ fun CustomUnitsScreenContent(
             ExtendedFloatingActionButton(
                 onClick = navigateToAddCustomUnit,
                 icon = {
-                    Icon(Icons.Default.Add, contentDescription = "Add custom unit")
+                    Icon(Icons.Default.Add, contentDescription = i18n("custom_units_add_action"))
                 },
                 text = {
-                    Text(text = "Custom unit")
+                    Text(text = i18n("custom_unit_singular"))
                 }
             )
         }
@@ -129,8 +130,8 @@ fun CustomUnitsScreenContent(
             }
             if (customUnits.isEmpty()) {
                 EmptyScreenDisclaimer(
-                    title = "No custom units yet",
-                    description = "Add your first unit."
+                    title = i18n("custom_units_empty_title"),
+                    description = i18n("custom_units_empty_description")
                 )
             }
         }

--- a/app/src/main/res/lang/en_us.xml
+++ b/app/src/main/res/lang/en_us.xml
@@ -7,6 +7,16 @@
     <string name="stats">Stats</string>
     <string name="settings">Settings</string>
     <string name="missing_key">[missing translation]</string>
+    <string name="settings_section_ui">UI</string>
+    <string name="settings_interaction_settings">Interaction settings</string>
+    <string name="settings_hide_dosage_dots">Hide dosage dots</string>
+    <string name="custom_units_title">Custom units</string>
+    <string name="custom_unit_singular">Custom unit</string>
+    <string name="custom_units_go_to_archive">Go to archive</string>
+    <string name="custom_units_add_action">Add custom unit</string>
+    <string name="custom_units_empty_title">No custom units yet</string>
+    <string name="custom_units_empty_description">Add your first unit.</string>
+    <string name="substance_colors_title">Substance colors</string>
     <string name="settings_language_with_value">Language: {language}</string>
     <string name="settings_language_title">Choose language</string>
     <string name="settings_language_system">From system</string>

--- a/app/src/main/res/lang/zh_cn.xml
+++ b/app/src/main/res/lang/zh_cn.xml
@@ -7,6 +7,16 @@
     <string name="stats">统计</string>
     <string name="settings">设置</string>
     <string name="missing_key">[缺少翻译]</string>
+    <string name="settings_section_ui">界面</string>
+    <string name="settings_interaction_settings">相互作用设置</string>
+    <string name="settings_hide_dosage_dots">隐藏剂量点</string>
+    <string name="custom_units_title">自定义单位</string>
+    <string name="custom_unit_singular">自定义单位</string>
+    <string name="custom_units_go_to_archive">前往归档</string>
+    <string name="custom_units_add_action">添加自定义单位</string>
+    <string name="custom_units_empty_title">暂无自定义单位</string>
+    <string name="custom_units_empty_description">添加你的第一个单位。</string>
+    <string name="substance_colors_title">物质颜色</string>
     <string name="settings_language_with_value">语言：{language}</string>
     <string name="settings_language_title">选择语言</string>
     <string name="settings_language_system">跟随系统</string>

--- a/app/src/main/res/lang/zh_tw.xml
+++ b/app/src/main/res/lang/zh_tw.xml
@@ -7,6 +7,16 @@
     <string name="stats">統計</string>
     <string name="settings">設定</string>
     <string name="missing_key">[缺少翻譯]</string>
+    <string name="settings_section_ui">介面</string>
+    <string name="settings_interaction_settings">相互作用設定</string>
+    <string name="settings_hide_dosage_dots">隱藏劑量點</string>
+    <string name="custom_units_title">自訂單位</string>
+    <string name="custom_unit_singular">自訂單位</string>
+    <string name="custom_units_go_to_archive">前往封存</string>
+    <string name="custom_units_add_action">新增自訂單位</string>
+    <string name="custom_units_empty_title">尚無自訂單位</string>
+    <string name="custom_units_empty_description">新增你的第一個單位。</string>
+    <string name="substance_colors_title">物質顏色</string>
     <string name="settings_language_with_value">語言：{language}</string>
     <string name="settings_language_title">選擇語言</string>
     <string name="settings_language_system">依系統</string>


### PR DESCRIPTION
### Motivation
- There were multiple hard-coded UI strings in the Settings and related screens that should be localized via the app's i18n system.
- Move visible labels such as Settings title, UI section, Custom units, Substance colors, Interaction settings and "Hide dosage dots" into the existing localization pipeline.
- Keep translations consistent across English, Simplified Chinese and Traditional Chinese language files.

### Description
- Replaced hardcoded strings in `SettingsScreen.kt` with `i18n(...)` lookups for keys like `settings`, `settings_section_ui`, `settings_interaction_settings`, and `settings_hide_dosage_dots`.
- Internationalized custom-units and related UI by updating `CustomUnitsScreen.kt` and the add-ingestion search header in `AddIngestionSearchScreen.kt` to use `i18n(...)` and importing the helper where needed.
- Replaced the Substance Colors screen title with `i18n(...)` in `SubstanceColorsScreen.kt`.
- Added new i18n keys and translations to `app/src/main/res/lang/en_us.xml`, `zh_cn.xml`, and `zh_tw.xml` for the introduced strings.

### Testing
- No automated tests were run as part of this change.
- The change was committed and staged files include the modified Kotlin source files and the three language XML files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696139eaca508330b1f109d7c4564b9d)