### PR TITLE
Refactor substance search into configurable searcher

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SearchRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SearchRepository.kt
@@ -44,38 +44,10 @@ class SearchRepository @Inject constructor(
     }
 
     private fun getSubstancesMatchingSearchText(searchText: String, prefilteredSubstances: List<SubstanceWithCategories>): List<SubstanceWithCategories> {
-        return if (searchText.isEmpty()) {
-            prefilteredSubstances
-        } else {
-            val searchString = searchText.replace(Regex("[- ]"), "")
-            // substances whose primary name begins with the search string
-            val mainPrefixMatches = prefilteredSubstances.filter { substanceWithCategories ->
-                substanceWithCategories.substance.name.replace(Regex("[- ]"), "").startsWith(
-                    prefix = searchString, ignoreCase = true
-                )
-            }
-            // substances with any name beginning with the search string
-            val prefixMatches = prefilteredSubstances.filter { substanceWithCategories ->
-                val allNames =
-                    substanceWithCategories.substance.commonNames + substanceWithCategories.substance.name
-                allNames.any { name ->
-                    name.replace(Regex("[- ]"), "").startsWith(
-                        prefix = searchString, ignoreCase = true
-                    )
-                }
-            }
-            // substances containing the search string in any of their names
-            val matches = prefilteredSubstances.filter { substanceWithCategories ->
-                val allNames =
-                    substanceWithCategories.substance.commonNames + substanceWithCategories.substance.name
-                allNames.any { name ->
-                    name.replace(Regex("[- ]"), "").contains(
-                        other = searchString, ignoreCase = true
-                    )
-                }
-            }
-            return (mainPrefixMatches + prefixMatches + matches).distinctBy { it.substance.name }
-        }
+        val sources = prefilteredSubstances.map { it.substance }
+        val matches = substanceRepo.searcher.search(searchText, sources)
+        val substanceByName = prefilteredSubstances.associateBy { it.substance.name }
+        return matches.mapNotNull { substanceByName[it.name] }
     }
 
     private fun getSubstancesSorted(

--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SubstanceRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/repositories/SubstanceRepository.kt
@@ -24,6 +24,8 @@ import com.isaakhanimann.journal.data.substances.classes.Substance
 import com.isaakhanimann.journal.data.substances.classes.SubstanceFile
 import com.isaakhanimann.journal.data.substances.classes.SubstanceWithCategories
 import com.isaakhanimann.journal.data.substances.parse.SubstanceParserInterface
+import com.isaakhanimann.journal.data.substances.search.DefaultSubstanceSearcher
+import com.isaakhanimann.journal.data.substances.search.SubstanceSearcher
 import com.isaakhanimann.journal.localization.I18n
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.json.JSONObject
@@ -45,6 +47,8 @@ class SubstanceRepository @Inject constructor(
 
     private var substanceFile: SubstanceFile
     private var loadedLanguageKey: String
+    var searcher: SubstanceSearcher = DefaultSubstanceSearcher()
+        private set
 
     init {
         val languageKey = I18n.getPreferredLanguageKey() ?: I18n.getCurrentLanguageKey()
@@ -57,6 +61,11 @@ class SubstanceRepository @Inject constructor(
         if (languageKey == loadedLanguageKey) return
         substanceFile = loadSubstanceFile(languageKey)
         loadedLanguageKey = languageKey
+        updateSearcher(languageKey)
+    }
+
+    fun updateSearcher(languageKey: String) {
+        searcher = DefaultSubstanceSearcher()
     }
 
     private fun loadSubstanceFile(languageKey: String): SubstanceFile {

--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/search/DefaultSubstanceSearcher.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/search/DefaultSubstanceSearcher.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024. Isaak Hanimann.
+ * This file is part of PsychonautWiki Journal.
+ *
+ * PsychonautWiki Journal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * PsychonautWiki Journal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ */
+
+package com.isaakhanimann.journal.data.substances.search
+
+import com.isaakhanimann.journal.data.substances.classes.Substance
+
+class DefaultSubstanceSearcher : SubstanceSearcher {
+    override fun search(word: String, sources: List<Substance>): List<Substance> {
+        if (word.isBlank()) {
+            return sources
+        }
+        val searchString = word.replace(Regex("[- ]"), "")
+        val mainPrefixMatches = sources.filter { substance ->
+            substance.name.replace(Regex("[- ]"), "").startsWith(
+                prefix = searchString,
+                ignoreCase = true
+            )
+        }
+        val prefixMatches = sources.filter { substance ->
+            val allNames = substance.commonNames + substance.name
+            allNames.any { name ->
+                name.replace(Regex("[- ]"), "").startsWith(
+                    prefix = searchString,
+                    ignoreCase = true
+                )
+            }
+        }
+        val matches = sources.filter { substance ->
+            val allNames = substance.commonNames + substance.name
+            allNames.any { name ->
+                name.replace(Regex("[- ]"), "").contains(
+                    other = searchString,
+                    ignoreCase = true
+                )
+            }
+        }
+        return (mainPrefixMatches + prefixMatches + matches).distinctBy { it.name }
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/search/SubstanceSearcher.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/search/SubstanceSearcher.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024. Isaak Hanimann.
+ * This file is part of PsychonautWiki Journal.
+ *
+ * PsychonautWiki Journal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * PsychonautWiki Journal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ */
+
+package com.isaakhanimann.journal.data.substances.search
+
+import com.isaakhanimann.journal.data.substances.classes.Substance
+
+interface SubstanceSearcher {
+    fun search(word: String, sources: List<Substance>): List<Substance>
+}


### PR DESCRIPTION
### Motivation
- Decouple the substance search logic so different search strategies can be provided and swapped later.
- Allow the searcher to be language-aware by updating it when the repository reloads language resources.
- Preserve existing matching and ranking behavior as the default while enabling future customization.

### Description
- Added a `SubstanceSearcher` interface with `fun search(word: String, sources: List<Substance>): List<Substance>` in `app/src/main/java/com/isaakhanimann/journal/data/substances/search/SubstanceSearcher.kt`.
- Implemented `DefaultSubstanceSearcher` that contains the existing prefix/contains matching and ranking logic in `DefaultSubstanceSearcher.kt`.
- Stored a `var searcher: SubstanceSearcher` in `SubstanceRepository`, initialized to `DefaultSubstanceSearcher()`, and added `fun updateSearcher(languageKey: String)` which currently assigns a new default instance.
- Changed `SearchRepository` to delegate text filtering to `substanceRepo.searcher.search(...)` and map the returned `Substance` results back to `SubstanceWithCategories` to preserve ordering.

### Testing
- No automated tests were executed as part of this change.
- The existing search behavior is preserved by `DefaultSubstanceSearcher` (manual verification intended in follow-ups).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696155b0e4dc8330b3904a0856df1e51)