### PR TITLE
Align google-services.json package name with app `applicationId`

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:366516140472:android:61bca0d7fd0b3229e7374d",
         "android_client_info": {
-          "package_name": "com.isaakhanimann.journal"
+          "package_name": "in.kawaiis.journal"
         }
       },
       "oauth_client": [


### PR DESCRIPTION
### Motivation
- Fix a mismatch between the package name in the Firebase configuration and the Android app `applicationId` to avoid Google services misconfiguration.

### Description
- Updated the `package_name` field in `app/google-services.json` from `com.isaakhanimann.journal` to `in.kawaiis.journal`.
- This change aligns the Firebase config in `app/google-services.json` with the `applicationId` declared in `app/build.gradle`.
- No other code or configuration files were modified.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961570b6d6883309a291d9f69e0d7b3)