### PR TITLE
Fix snackbar i18n usage and latest-ingestion Room query

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
@@ -55,10 +55,10 @@ interface ExperienceDao {
     fun getIngestionsSortedDescendingFlow(): Flow<List<Ingestion>>
 
     @Query(
-        "SELECT i.* FROM ingestion as i" +
-                " INNER JOIN (SELECT substanceName, MAX(time) AS maxTime FROM ingestion WHERE time > :instant GROUP BY substanceName) as sub" +
-                " ON i.substanceName = sub.substanceName AND i.time = sub.maxTime" +
-                " ORDER BY i.time DESC"
+        "SELECT * FROM ingestion as i" +
+                " INNER JOIN (SELECT id, MAX(time) AS maxTime FROM ingestion WHERE time > :instant GROUP BY substanceName) as sub" +
+                " ON i.id = sub.id AND i.time = sub.maxTime" +
+                " ORDER BY time DESC"
     )
     @RewriteQueriesToDropUnusedColumns
     suspend fun getLatestIngestionOfEverySubstanceSinceDate(instant: Instant): List<Ingestion>

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
@@ -55,10 +55,10 @@ interface ExperienceDao {
     fun getIngestionsSortedDescendingFlow(): Flow<List<Ingestion>>
 
     @Query(
-        "SELECT * FROM ingestion as i" +
-                " INNER JOIN (SELECT id, MAX(time) AS maxTime FROM ingestion WHERE time > :instant GROUP BY substanceName) as sub" +
-                " ON i.id = sub.id AND i.time = sub.maxTime" +
-                " ORDER BY time DESC"
+        "SELECT i.* FROM ingestion as i" +
+                " INNER JOIN (SELECT substanceName, MAX(time) AS maxTime FROM ingestion WHERE time > :instant GROUP BY substanceName) as sub" +
+                " ON i.substanceName = sub.substanceName AND i.time = sub.maxTime" +
+                " ORDER BY i.time DESC"
     )
     @RewriteQueriesToDropUnusedColumns
     suspend fun getLatestIngestionOfEverySubstanceSinceDate(instant: Instant): List<Ingestion>

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -326,6 +326,7 @@ fun SettingsScreen(
                     isShowingDeleteDialog = true
                 }
                 val scope = rememberCoroutineScope()
+                val deletedSnackbarMessage = i18n("settings_deleted_snackbar")
                 AnimatedVisibility(visible = isShowingDeleteDialog) {
                     AlertDialog(
                         onDismissRequest = { isShowingDeleteDialog = false },
@@ -342,7 +343,7 @@ fun SettingsScreen(
                                     deleteEverything()
                                     scope.launch {
                                         snackbarHostState.showSnackbar(
-                                            message = i18n("settings_deleted_snackbar"),
+                                            message = deletedSnackbarMessage,
                                             duration = SnackbarDuration.Short
                                         )
                                     }


### PR DESCRIPTION
### Motivation
- Calling the `@Composable` `i18n` function inside a coroutine caused an illegal composable invocation and needed to be avoided.
- Room was warning that the latest-ingestion query returned unused columns, causing a `kapt`/cursor mismatch warning.
- The intent is to prevent runtime/compile issues in the settings UI and ensure the Room query only returns ingestion columns. 

### Description
- Capture the snackbar text ahead of the coroutine by assigning `val deletedSnackbarMessage = i18n("settings_deleted_snackbar")` in `SettingsScreen.kt` and use that value in the coroutine. 
- Replace the previous `i18n` call inside `scope.launch { ... }` with the captured `deletedSnackbarMessage` to avoid calling a composable from a coroutine. 
- Update the SQL in `ExperienceDao.kt` to `SELECT i.* FROM ingestion as i` and join on `substanceName`/`time` via a subquery that selects `substanceName, MAX(time) AS maxTime`, and order by `i.time DESC` so only ingestion columns are returned. 
- Keep the `@RewriteQueriesToDropUnusedColumns` annotation to help Room avoid fetching unused columns if any remain. 

### Testing
- No automated tests or builds were executed as part of this change. 
- Recommend running `./gradlew :app:compileDebugKotlin` and `./gradlew connectedAndroidTest` after merging to validate compile and instrumentation tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615a5c800883308f2b326240842442)