### PR TITLE
Include localized names in default substance search

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/data/substances/search/DefaultSubstanceSearcher.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/substances/search/DefaultSubstanceSearcher.kt
@@ -33,7 +33,7 @@ class DefaultSubstanceSearcher : SubstanceSearcher {
             )
         }
         val prefixMatches = sources.filter { substance ->
-            val allNames = substance.commonNames + substance.name
+            val allNames = substance.commonNames + listOfNotNull(substance.name, substance.localizedName)
             allNames.any { name ->
                 name.replace(Regex("[- ]"), "").startsWith(
                     prefix = searchString,
@@ -42,7 +42,7 @@ class DefaultSubstanceSearcher : SubstanceSearcher {
             }
         }
         val matches = sources.filter { substance ->
-            val allNames = substance.commonNames + substance.name
+            val allNames = substance.commonNames + listOfNotNull(substance.name, substance.localizedName)
             allNames.any { name ->
                 name.replace(Regex("[- ]"), "").contains(
                     other = searchString,


### PR DESCRIPTION
### Motivation
- Make search more inclusive by considering a substance's localized display name (`localizedName`) so users can find substances by their localized names.
- The previous implementation only used `commonNames` and the primary `name` for prefix and substring matching, which missed localized variants.
- Preserve the existing prioritization where the primary `name` prefix matches remain handled by `mainPrefixMatches`.

### Description
- Modify `app/src/main/java/com/isaakhanimann/journal/data/substances/search/DefaultSubstanceSearcher.kt` to construct `allNames` as `substance.commonNames + listOfNotNull(substance.name, substance.localizedName)` for both `prefixMatches` and `matches`.
- This change makes `prefixMatches` and `matches` include localized names while leaving `mainPrefixMatches` unchanged.
- Search result composition is unchanged and still returns `(mainPrefixMatches + prefixMatches + matches).distinctBy { it.name }`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961d9e3e5cc83308e9f3ede5eeebf3c)