### PR TITLE
feat: add release signing config with GitHub Secrets support

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -29,11 +29,21 @@ jobs:
       - name: Grant Gradle execute permission
         run: chmod +x ./gradlew
 
-      - name: Build debug APK
+      - name: Build release APK (main repo)
+        if: github.repository == 'LoliLin/journal-android-multilingual'
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Build debug APK (forks)
+        if: github.repository != 'LoliLin/journal-android-multilingual'
         run: ./gradlew assembleDebug --stacktrace
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug
-          path: app/build/outputs/apk/debug/app-debug.apk
+          name: app-${{ github.repository != 'LoliLin/journal-android-multilingual' && 'debug' || 'release' }}
+          path: app/build/outputs/apk/${{ github.repository != 'LoliLin/journal-android-multilingual' && 'debug' || 'release' }}/app-*.apk

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 local.properties
 release
 .alma-snapshots
+*.keystore.jks
+*.keystore
+keystore_b64.txt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "in.kawaiis.journal"
         minSdk 26
         targetSdk 34
-        versionCode 29
-        versionName "8.5"
+        versionCode 30
+        versionName "27.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -31,11 +31,12 @@ android {
 
     signingConfigs {
         release {
-            if (System.getenv("KEYSTORE_BASE64") != null) {
+            def b64 = System.getenv("KEYSTORE_BASE64")
+            if (b64 != null && !b64.isBlank()) {
+                b64 = b64.trim().replaceAll("\\s", "")
                 def keystoreFile = file("${project.buildDir}/release.keystore.jks")
                 keystoreFile.parentFile.mkdirs()
-                def decoded = java.util.Base64.getDecoder().decode(System.getenv("KEYSTORE_BASE64"))
-                keystoreFile.bytes = decoded
+                keystoreFile.bytes = java.util.Base64.getDecoder().decode(b64)
                 storeFile = keystoreFile
                 storePassword = System.getenv("KEYSTORE_PASSWORD")
                 keyAlias = System.getenv("KEY_ALIAS")
@@ -45,9 +46,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            signingConfig signingConfigs.debug
-        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,27 @@ android {
         }
     }
 
-    buildTypes {
+    signingConfigs {
         release {
+            if (System.getenv("KEYSTORE_BASE64") != null) {
+                def keystoreFile = file("${project.buildDir}/release.keystore.jks")
+                keystoreFile.parentFile.mkdirs()
+                def decoded = System.getenv("KEYSTORE_BASE64").bytes.decodeBase64()
+                keystoreFile.bytes = decoded
+                storeFile = keystoreFile
+                storePassword = System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
             if (System.getenv("KEYSTORE_BASE64") != null) {
                 def keystoreFile = file("${project.buildDir}/release.keystore.jks")
                 keystoreFile.parentFile.mkdirs()
-                def decoded = System.getenv("KEYSTORE_BASE64").bytes.decodeBase64()
+                def decoded = java.util.Base64.getDecoder().decode(System.getenv("KEYSTORE_BASE64"))
                 keystoreFile.bytes = decoded
                 storeFile = keystoreFile
                 storePassword = System.getenv("KEYSTORE_PASSWORD")


### PR DESCRIPTION
- Generate release keystore (release.keystore.jks, gitignored)
- Add signingConfigs block in build.gradle (reads env vars)
- Update workflow: signed release for main repo, debug for forks
- Add keystore artifacts to .gitignore