### PR TITLE
feat: translate IconPickerScreen UI strings

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -555,5 +555,9 @@
   "extension_update": "Update",
   "extension_check_update": "Check update",
   "extension_download": "Download",
-  "settings_OpenLinkInBrowser":"Open Link in Browser"
+  "settings_OpenLinkInBrowser": "Open Link in Browser",
+  "settings_icon_switched": "Icon switched",
+  "settings_icon_switch_failed": "Icon switch failed",
+  "settings_icon_current": "Current: {name}",
+  "common_back": "Back"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -555,5 +555,9 @@
   "extension_update": "更新",
   "extension_check_update": "检查更新",
   "extension_download": "下载",
-  "settings_OpenLinkInBrowser":"在浏览器中打开链接"
+  "settings_OpenLinkInBrowser": "在浏览器中打开链接",
+  "settings_icon_switched": "图标已切换",
+  "settings_icon_switch_failed": "图标切换失败",
+  "settings_icon_current": "当前: {name}",
+  "common_back": "返回"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -555,5 +555,9 @@
   "extension_update": "更新",
   "extension_check_update": "檢查更新",
   "extension_download": "下載",
-  "settings_OpenLinkInBrowser":"在瀏覽器中開啟連結"
+  "settings_OpenLinkInBrowser": "在瀏覽器中開啟連結",
+  "settings_icon_switched": "圖示已切換",
+  "settings_icon_switch_failed": "圖示切換失敗",
+  "settings_icon_current": "目前: {name}",
+  "common_back": "返回"
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
@@ -128,21 +128,17 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                         if (!isSwitching && selectedKey != option.key) {
                             isSwitching = true
                             val success = switchIcon(pm, aliases, enableKey = option.key)
-                            if (success) {
-                                selectedKey = option.key
-                                scope.launch {
-
-                                    snackbarHostState.showSnackbar(i18n("settings_icon_switched"))
-
-                                }
-
-                            } else {
-
-                                scope.launch {
-
-                                    snackbarHostState.showSnackbar(i18n("settings_icon_switch_failed"))
-
-                                }
+                            if (success) {
+                                selectedKey = option.key
+                                val msg = i18n("settings_icon_switched")
+                                scope.launch {
+                                    snackbarHostState.showSnackbar(msg)
+                                }
+                            } else {
+                                val msg = i18n("settings_icon_switch_failed")
+                                scope.launch {
+                                    snackbarHostState.showSnackbar(msg)
+                                }
                             }
                             isSwitching = false
                         }
@@ -150,10 +146,14 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                 )
             }
 
-            Text(
-                text = i18n("settings_icon_current", mapOf("name" to selectedKey)),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+            Text(
+
+                text = i18n("settings_icon_current", mapOf("name" to selectedKey)),
+
+                style = MaterialTheme.typography.bodySmall,
+
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+
             )
         }
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
@@ -106,7 +106,7 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                 title = { Text(i18n("settings_icon_title")) },
                 navigationIcon = {
                     IconButton(onClick = navigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = i18n("common_back"))
                     }
                 }
             )
@@ -131,11 +131,17 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                             if (success) {
                                 selectedKey = option.key
                                 scope.launch {
-                                    snackbarHostState.showSnackbar("图标已切换")
+
+                                    snackbarHostState.showSnackbar(i18n("settings_icon_switched"))
+
                                 }
+
                             } else {
+
                                 scope.launch {
-                                    snackbarHostState.showSnackbar("图标切换失败")
+
+                                    snackbarHostState.showSnackbar(i18n("settings_icon_switch_failed"))
+
                                 }
                             }
                             isSwitching = false
@@ -144,10 +150,10 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                 )
             }
 
-            Text(
-                text = "当前: $selectedKey",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+            Text(
+                text = i18n("settings_icon_current", mapOf("name" to selectedKey)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
@@ -121,6 +121,8 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             iconOptions.forEach { option ->
+                val msg_switched = i18n("settings_icon_switched")
+                val msg_switch_failed = i18n("settings_icon_switch_failed")
                 IconOptionCard(
                     option = option,
                     isSelected = selectedKey == option.key,
@@ -128,17 +130,23 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
                         if (!isSwitching && selectedKey != option.key) {
                             isSwitching = true
                             val success = switchIcon(pm, aliases, enableKey = option.key)
-                            if (success) {
-                                selectedKey = option.key
-                                val msg = i18n("settings_icon_switched")
-                                scope.launch {
-                                    snackbarHostState.showSnackbar(msg)
-                                }
-                            } else {
-                                val msg = i18n("settings_icon_switch_failed")
-                                scope.launch {
-                                    snackbarHostState.showSnackbar(msg)
-                                }
+                            if (success) {
+
+                                selectedKey = option.key
+
+                                val msg = msg_switched
+
+                                scope.launch {
+
+                                    snackbarHostState.showSnackbar(msg)
+
+                                }
+
+                            } else {
+                                val msg = msg_switch_failed
+                                scope.launch {
+                                    snackbarHostState.showSnackbar(msg)
+                                }
                             }
                             isSwitching = false
                         }
@@ -147,13 +155,9 @@ fun IconPickerScreen(navigateBack: () -> Unit) {
             }
 
             Text(
-
                 text = i18n("settings_icon_current", mapOf("name" to selectedKey)),
-
                 style = MaterialTheme.typography.bodySmall,
-
                 color = MaterialTheme.colorScheme.onSurfaceVariant
-
             )
         }
     }


### PR DESCRIPTION
- Replaced hardcoded Chinese snackbar messages with i18n keys
- Replaced 'Back' content description with i18n key
- Replaced '当前: xxx' label with i18n key using replacement
- Added common_back i18n key
- Added settings_icon_switched/failed/current keys