### PR TITLE
feat: translate cross-tolerance names via display name lookup

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
@@ -332,10 +332,11 @@ fun SubstanceScreen(
                 SectionWithTitle(title = i18n("substance_tolerance_title")) {
                     Column {
                         VerticalSpace()
-                        ToleranceSection(
-                            tolerance = substance.tolerance,
-                            crossTolerances = substance.crossTolerances,
-                            modifier = Modifier.padding(horizontal = horizontalPadding)
+                        ToleranceSection(
+                            tolerance = substance.tolerance,
+                            crossTolerances = substance.crossTolerances,
+                            modifier = Modifier.padding(horizontal = horizontalPadding),
+                            getSubstanceDisplayName = { name -> interactionNameLookup[name] ?: name }
                         )
                         VerticalSpace()
                     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/roa/ToleranceSection.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/roa/ToleranceSection.kt
@@ -47,58 +47,60 @@ fun ToleranceSectionPreview() {
     )
 }
 
-@Composable
-fun ToleranceSection(
-    tolerance: Tolerance?,
-    crossTolerances: List<String>,
-    modifier: Modifier = Modifier
-) {
-    if (tolerance != null || crossTolerances.isNotEmpty()) {
-        Column(modifier) {
-            if (tolerance != null) {
-                val labelWidth = 40.dp
-                Row(
-                    verticalAlignment = Alignment.Top
-                ) {
-                    if (tolerance.full != null) {
-                        Text(
-                            text = i18n("tolerance_full_label"),
-                            modifier = Modifier.width(labelWidth)
-                        )
-                        Text(text = tolerance.full)
-                    }
-                }
-                Row(
-                    verticalAlignment = Alignment.Top
-                ) {
-                    if (tolerance.half != null) {
-                        Text(
-                            text = i18n("tolerance_half_label"),
-                            modifier = Modifier.width(labelWidth)
-                        )
-                        Text(text = tolerance.half)
-                    }
-                }
-                Row(
-                    verticalAlignment = Alignment.Top
-                ) {
-                    if (tolerance.zero != null) {
-                        Text(
-                            text = i18n("tolerance_zero_label"),
-                            modifier = Modifier.width(labelWidth)
-                        )
-                        Text(text = tolerance.zero)
-                    }
-                }
-                Text(text = i18n("tolerance_zero_explanation"), style = MaterialTheme.typography.bodySmall)
-            }
-            if (crossTolerances.isNotEmpty()) {
-                val names = crossTolerances.map { it }.distinct()
-                    .joinToString(separator = ", ")
-                Text(text = i18n("tolerance_cross_with", mapOf("names" to names)))
-            }
-        }
-
-    }
-
+@Composable
+fun ToleranceSection(
+    tolerance: Tolerance?,
+    crossTolerances: List<String>,
+    modifier: Modifier = Modifier,
+    getSubstanceDisplayName: ((String) -> String)? = null
+) {
+    if (tolerance != null || crossTolerances.isNotEmpty()) {
+        Column(modifier) {
+            if (tolerance != null) {
+                val labelWidth = 40.dp
+                Row(
+                    verticalAlignment = Alignment.Top
+                ) {
+                    if (tolerance.full != null) {
+                        Text(
+                            text = i18n("tolerance_full_label"),
+                            modifier = Modifier.width(labelWidth)
+                        )
+                        Text(text = tolerance.full)
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.Top
+                ) {
+                    if (tolerance.half != null) {
+                        Text(
+                            text = i18n("tolerance_half_label"),
+                            modifier = Modifier.width(labelWidth)
+                        )
+                        Text(text = tolerance.half)
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.Top
+                ) {
+                    if (tolerance.zero != null) {
+                        Text(
+                            text = i18n("tolerance_zero_label"),
+                            modifier = Modifier.width(labelWidth)
+                        )
+                        Text(text = tolerance.zero)
+                    }
+                }
+                Text(text = i18n("tolerance_zero_explanation"), style = MaterialTheme.typography.bodySmall)
+            }
+            if (crossTolerances.isNotEmpty()) {
+                val names = crossTolerances.map { name ->
+                    getSubstanceDisplayName?.invoke(name) ?: name
+                }.distinct().joinToString(separator = ", ")
+                Text(text = i18n("tolerance_cross_with", mapOf("names" to names)))
+            }
+        }
+
+    }
+
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/substancecompanion/SubstanceCompanionScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/substancecompanion/SubstanceCompanionScreen.kt
@@ -129,9 +129,12 @@ fun SubstanceCompanionScreen(
             item {
                 if (tolerance != null || crossTolerances.isNotEmpty()) {
                     CardWithTitle(title = i18n("substance_tolerance_title"), modifier = Modifier.fillMaxWidth()) {
-                        ToleranceSection(
-                            tolerance = tolerance,
-                            crossTolerances = crossTolerances
+                        ToleranceSection(
+                            tolerance = tolerance,
+                            crossTolerances = crossTolerances,
+                            getSubstanceDisplayName = substanceRepo?.let { repo ->
+                                { name -> repo.getDisplayName(name) }
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
- ToleranceSection now accepts getSubstanceDisplayName callback
- Cross-tolerance names like 'dopamine', 'stimulant' now show translated names
- Callers in SubstanceScreen and SubstanceCompanionScreen pass the display name function
- Categories were already translated via getLocalizedName/getLocalizedDescription