### PR TITLE
feat: quick timed notes, effect notifications, time capsule

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,7 @@ dependencies {
 
     implementation(libs.androidx.browser)
     implementation(libs.androidx.biometric)
+    implementation(libs.androidx.work)
 
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -118,6 +119,8 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler) 
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
 
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name=".di.JournalApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity-alias>
+        <receiver
+            android:name=".ui.notifications.EffectNotificationReceiver"
+            android:exported="false" />
         <provider
           android:name="androidx.core.content.FileProvider"
           android:authorities="in.kawaiis.journal.fileprovider" 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,6 +63,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity-alias>
+        <!-- JournalApplication implements Configuration.Provider (on-demand WorkManager
+             initialization), so the default startup initializer must be removed. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
         <receiver
             android:name=".ui.notifications.EffectNotificationReceiver"
             android:exported="false" />

--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -598,5 +598,17 @@
   "time_capsule_notification_title": "Time capsule: this day last year",
   "time_capsule_notification_text": "You recorded {count} experiences this day last year",
   "time_capsule_screen_title": "This day last year",
-  "time_capsule_empty": "Nothing was recorded this day last year"
+  "time_capsule_empty": "Nothing was recorded this day last year",
+  "stats_report_title": "Stats report",
+  "stats_report_records": "Records",
+  "stats_report_experiences": "Experiences",
+  "stats_report_substances": "Substances",
+  "stats_report_trend": "Trend",
+  "stats_report_top": "Top substances",
+  "stats_report_generated": "Generated {date}",
+  "stats_report_period_days_7": "Last 7 days",
+  "stats_report_period_days_30": "Last 30 days",
+  "stats_report_period_weeks_26": "Last 6 months",
+  "stats_report_period_months_12": "Last 12 months",
+  "stats_report_period_years_10": "Last 10 years"
 }

--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -583,5 +583,20 @@
   "settings_icon_switched": "Icon switched",
   "settings_icon_switch_failed": "Icon switch failed",
   "settings_icon_current": "Current: {name}",
-  "common_back": "Back"
+  "common_back": "Back",
+  "common_untitled": "Untitled",
+  "quick_note_title": "Quick note",
+  "quick_note_hint": "What's happening?",
+  "effect_notification_channel": "Active effects",
+  "effect_notification_title": "Effects in progress",
+  "effect_notification_text": "{substance} · since {time}",
+  "effect_notification_action_note": "Add note",
+  "effect_notification_action_stop": "End effects",
+  "settings_effect_notification": "Effect notifications",
+  "settings_effect_notification_description": "Keep a notification with quick note access while effects last",
+  "time_capsule_channel": "Time capsule",
+  "time_capsule_notification_title": "Time capsule: this day last year",
+  "time_capsule_notification_text": "You recorded {count} experiences this day last year",
+  "time_capsule_screen_title": "This day last year",
+  "time_capsule_empty": "Nothing was recorded this day last year"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -598,5 +598,17 @@
   "time_capsule_notification_title": "时间胶囊：去年的今天",
   "time_capsule_notification_text": "去年的今天你记录了 {count} 个体验",
   "time_capsule_screen_title": "去年的今天",
-  "time_capsule_empty": "去年的今天没有记录"
+  "time_capsule_empty": "去年的今天没有记录",
+  "stats_report_title": "统计报告",
+  "stats_report_records": "记录次数",
+  "stats_report_experiences": "体验",
+  "stats_report_substances": "物质",
+  "stats_report_trend": "趋势",
+  "stats_report_top": "物质排行",
+  "stats_report_generated": "生成于 {date}",
+  "stats_report_period_days_7": "最近 7 天",
+  "stats_report_period_days_30": "最近 30 天",
+  "stats_report_period_weeks_26": "最近 6 个月",
+  "stats_report_period_months_12": "最近 12 个月",
+  "stats_report_period_years_10": "最近 10 年"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -583,5 +583,20 @@
   "settings_icon_switched": "图标已切换",
   "settings_icon_switch_failed": "图标切换失败",
   "settings_icon_current": "当前: {name}",
-  "common_back": "返回"
+  "common_back": "返回",
+  "common_untitled": "无标题",
+  "quick_note_title": "快速笔记",
+  "quick_note_hint": "现在感觉如何？",
+  "effect_notification_channel": "药效进行中",
+  "effect_notification_title": "药效进行中",
+  "effect_notification_text": "{substance} · 自 {time}",
+  "effect_notification_action_note": "记录笔记",
+  "effect_notification_action_stop": "结束药效",
+  "settings_effect_notification": "药效期通知",
+  "settings_effect_notification_description": "药效期间显示通知，可随时快速记录笔记",
+  "time_capsule_channel": "时间胶囊",
+  "time_capsule_notification_title": "时间胶囊：去年的今天",
+  "time_capsule_notification_text": "去年的今天你记录了 {count} 个体验",
+  "time_capsule_screen_title": "去年的今天",
+  "time_capsule_empty": "去年的今天没有记录"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -583,5 +583,20 @@
   "settings_icon_switched": "圖示已切換",
   "settings_icon_switch_failed": "圖示切換失敗",
   "settings_icon_current": "目前: {name}",
-  "common_back": "返回"
+  "common_back": "返回",
+  "common_untitled": "無標題",
+  "quick_note_title": "快速筆記",
+  "quick_note_hint": "現在感覺如何？",
+  "effect_notification_channel": "藥效進行中",
+  "effect_notification_title": "藥效進行中",
+  "effect_notification_text": "{substance} · 自 {time}",
+  "effect_notification_action_note": "記錄筆記",
+  "effect_notification_action_stop": "結束藥效",
+  "settings_effect_notification": "藥效期通知",
+  "settings_effect_notification_description": "藥效期間顯示通知，可隨時快速記錄筆記",
+  "time_capsule_channel": "時間膠囊",
+  "time_capsule_notification_title": "時間膠囊：去年的今天",
+  "time_capsule_notification_text": "去年的今天你記錄了 {count} 個體驗",
+  "time_capsule_screen_title": "去年的今天",
+  "time_capsule_empty": "去年的今天沒有記錄"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -598,5 +598,17 @@
   "time_capsule_notification_title": "時間膠囊：去年的今天",
   "time_capsule_notification_text": "去年的今天你記錄了 {count} 個體驗",
   "time_capsule_screen_title": "去年的今天",
-  "time_capsule_empty": "去年的今天沒有記錄"
+  "time_capsule_empty": "去年的今天沒有記錄",
+  "stats_report_title": "統計報告",
+  "stats_report_records": "記錄次數",
+  "stats_report_experiences": "體驗",
+  "stats_report_substances": "物質",
+  "stats_report_trend": "趨勢",
+  "stats_report_top": "物質排行",
+  "stats_report_generated": "產生於 {date}",
+  "stats_report_period_days_7": "最近 7 天",
+  "stats_report_period_days_30": "最近 30 天",
+  "stats_report_period_weeks_26": "最近 6 個月",
+  "stats_report_period_months_12": "最近 12 個月",
+  "stats_report_period_years_10": "最近 10 年"
 }

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
@@ -67,6 +67,15 @@ interface ExperienceDao {
     @Query("SELECT * FROM experience ORDER BY sortDate")
     suspend fun getAllExperiencesWithIngestionsTimedNotesAndRatingsSorted(): List<ExperienceWithIngestionsTimedNotesAndRatings>
 
+    @Transaction
+    @Query(
+        "SELECT * FROM experience WHERE sortDate >= :fromInstant AND sortDate < :toInstant ORDER BY sortDate"
+    )
+    suspend fun getExperiencesWithIngestionsTimedNotesAndRatingsInRange(
+        fromInstant: Instant,
+        toInstant: Instant
+    ): List<ExperienceWithIngestionsTimedNotesAndRatings>
+
     @Query("SELECT * FROM customunit ORDER BY creationDate")
     suspend fun getAllCustomUnitsSorted(): List<CustomUnit>
 

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
@@ -171,6 +171,15 @@ class ExperienceRepository @Inject constructor(private val experienceDao: Experi
     suspend fun getAllExperiencesWithIngestionsTimedNotesAndRatingsSorted(): List<ExperienceWithIngestionsTimedNotesAndRatings> =
         experienceDao.getAllExperiencesWithIngestionsTimedNotesAndRatingsSorted()
 
+    suspend fun getExperiencesWithIngestionsTimedNotesAndRatingsInRange(
+        fromInstant: Instant,
+        toInstant: Instant
+    ): List<ExperienceWithIngestionsTimedNotesAndRatings> =
+        experienceDao.getExperiencesWithIngestionsTimedNotesAndRatingsInRange(
+            fromInstant,
+            toInstant
+        )
+
     suspend fun getAllCustomUnitsSorted(): List<CustomUnit> =
         experienceDao.getAllCustomUnitsSorted()
 

--- a/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
@@ -1,25 +1,41 @@
-/*
- * Copyright (c) 2022. Isaak Hanimann.
- * This file is part of PsychonautWiki Journal.
- *
- * PsychonautWiki Journal is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * PsychonautWiki Journal is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
- */
-
 package com.isaakhanimann.journal.di
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.isaakhanimann.journal.ui.notifications.Notifications
+import com.isaakhanimann.journal.ui.notifications.TimeCapsuleWorker
 import dagger.hilt.android.HiltAndroidApp
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 @HiltAndroidApp
-class JournalApplication : Application()
+class JournalApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        Notifications.createChannels(this)
+        // Daily time-capsule check: "this day last year".
+        val request = PeriodicWorkRequestBuilder<TimeCapsuleWorker>(1, TimeUnit.DAYS).build()
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            TIME_CAPSULE_WORK_NAME,
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
+
+    companion object {
+        private const val TIME_CAPSULE_WORK_NAME = "time_capsule_daily"
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2022-2023. Isaak Hanimann.
+ * This file is part of PsychonautWiki Journal.
+ *
+ * PsychonautWiki Journal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * PsychonautWiki Journal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ */
+
 package com.isaakhanimann.journal.di
 
 import android.app.Application
@@ -30,7 +48,9 @@ class JournalApplication : Application(), Configuration.Provider {
         val request = PeriodicWorkRequestBuilder<TimeCapsuleWorker>(1, TimeUnit.DAYS).build()
         WorkManager.getInstance(this).enqueueUniquePeriodicWork(
             TIME_CAPSULE_WORK_NAME,
-            ExistingPeriodicWorkPolicy.KEEP,
+            // UPDATE so a future change to the worker spec (interval/constraints)
+            // is picked up on the next launch instead of lingering on the old one.
+            ExistingPeriodicWorkPolicy.UPDATE,
             request
         )
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/AppLockScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/AppLockScreen.kt
@@ -76,6 +76,9 @@ fun AppLockScreen(onUnlocked: () -> Unit) {
         {
             val keyguardManager =
                 context.getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+            // Deprecated on API 33+ in favor of BiometricPrompt's DEVICE_CREDENTIAL,
+            // but kept deliberately as the library-independent fallback channel.
+            @Suppress("DEPRECATION")
             val intent = keyguardManager?.createConfirmDeviceCredentialIntent(
                 titleText,
                 subtitleText
@@ -105,7 +108,9 @@ fun AppLockScreen(onUnlocked: () -> Unit) {
                     BiometricManager.from(context).canAuthenticate(authenticators)
                 } else {
                     // DEVICE_CREDENTIAL only exists on API 30+; on older devices fall
-                    // back to the no-arg check (biometric-only).
+                    // back to the no-arg check (biometric-only). The no-arg overload is
+                    // deprecated upstream but is the only option below API 30.
+                    @Suppress("DEPRECATION")
                     BiometricManager.from(context).canAuthenticate()
                 }
                 if (canAuthenticate == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -79,6 +79,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     DisposableEffect(activity) {
         val listener = { intent: android.content.Intent ->
             parseNavIntent(intent)?.let { pendingNav = it }
+            Unit
         }
         activity?.addOnNewIntentListener(listener)
         onDispose { activity?.removeOnNewIntentListener(listener) }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -79,7 +79,6 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     DisposableEffect(activity) {
         val listener = { intent: android.content.Intent ->
             parseNavIntent(intent)?.let { pendingNav = it }
-            true
         }
         activity?.addOnNewIntentListener(listener)
         onDispose { activity?.removeOnNewIntentListener(listener) }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -100,22 +100,12 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     } else {
         val navController = rememberNavController()
         LaunchedEffect(pendingNav) {
-            val navigation = pendingNav
-            if (navigation != null) {
-                // Wait one frame so the NavHost graph is fully attached before navigating
-                // (relevant right after unlocking — this branch composes for the first time).
-                kotlinx.coroutines.delay(150)
-                android.util.Log.i("MainScreen", "consuming pendingNav: $navigation")
-                try {
-                    val (target, experienceId) = navigation
-                    when (target) {
-                        NAV_QUICK_NOTE -> if (experienceId > 0) {
-                            navController.navigateToQuickTimedNote(experienceId)
-                        }
-                        NAV_TIME_CAPSULE -> navController.navigateToTimeCapsule()
+            pendingNav?.let { (target, experienceId) ->
+                when (target) {
+                    NAV_QUICK_NOTE -> if (experienceId > 0) {
+                        navController.navigateToQuickTimedNote(experienceId)
                     }
-                } catch (e: Exception) {
-                    android.util.Log.e("MainScreen", "navigation failed", e)
+                    NAV_TIME_CAPSULE -> navController.navigateToTimeCapsule()
                 }
                 pendingNav = null
             }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -100,12 +100,22 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     } else {
         val navController = rememberNavController()
         LaunchedEffect(pendingNav) {
-            pendingNav?.let { (target, experienceId) ->
-                when (target) {
-                    NAV_QUICK_NOTE -> if (experienceId > 0) {
-                        navController.navigateToQuickTimedNote(experienceId)
+            val navigation = pendingNav
+            if (navigation != null) {
+                // Wait one frame so the NavHost graph is fully attached before navigating
+                // (relevant right after unlocking — this branch composes for the first time).
+                kotlinx.coroutines.delay(150)
+                android.util.Log.i("MainScreen", "consuming pendingNav: $navigation")
+                try {
+                    val (target, experienceId) = navigation
+                    when (target) {
+                        NAV_QUICK_NOTE -> if (experienceId > 0) {
+                            navController.navigateToQuickTimedNote(experienceId)
+                        }
+                        NAV_TIME_CAPSULE -> navController.navigateToTimeCapsule()
                     }
-                    NAV_TIME_CAPSULE -> navController.navigateToTimeCapsule()
+                } catch (e: Exception) {
+                    android.util.Log.e("MainScreen", "navigation failed", e)
                 }
                 pendingNav = null
             }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -27,9 +27,12 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -40,12 +43,23 @@ import androidx.navigation.compose.rememberNavController
 import com.isaakhanimann.journal.localization.I18n
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.main.navigation.graphs.journalGraph
+import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToQuickTimedNote
+import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToTimeCapsule
+import com.isaakhanimann.journal.ui.notifications.EXTRA_EXPERIENCE_ID
+import com.isaakhanimann.journal.ui.notifications.EXTRA_NAVIGATE_TO
+import com.isaakhanimann.journal.ui.notifications.NAV_QUICK_NOTE
+import com.isaakhanimann.journal.ui.notifications.NAV_TIME_CAPSULE
 import com.isaakhanimann.journal.ui.main.navigation.graphs.saferGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.searchGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.settingsGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.statsGraph
 import com.isaakhanimann.journal.ui.main.navigation.routers.TabRouter
 import com.isaakhanimann.journal.ui.utils.keyboard.isKeyboardOpen
+
+private fun parseNavIntent(intent: android.content.Intent?): Pair<String, Int>? {
+    val target = intent?.getStringExtra(EXTRA_NAVIGATE_TO) ?: return null
+    return target to intent.getIntExtra(EXTRA_EXPERIENCE_ID, -1)
+}
 
 @Composable
 fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
@@ -54,6 +68,24 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         I18n.setPreferredLanguageKey(selectedLanguageKey)
     }
     val isAccepted = viewModel.isAcceptedFlow.collectAsState().value
+
+    // Notification taps can steer the app to a target screen (quick note / time capsule).
+    // Tracked above the gate so the intent survives the accept/lock screens and is
+    // consumed by the content branch once it composes.
+    var pendingNav by remember { mutableStateOf<Pair<String, Int>?>(null) }
+    val activity = LocalContext.current as? androidx.activity.ComponentActivity
+    DisposableEffect(activity) {
+        val listener = androidx.activity.OnNewIntentListener { intent ->
+            parseNavIntent(intent)?.let { pendingNav = it }
+            true
+        }
+        activity?.addOnNewIntentListener(listener)
+        onDispose { activity?.removeOnNewIntentListener(listener) }
+    }
+    LaunchedEffect(Unit) {
+        parseNavIntent(activity?.intent)?.let { pendingNav = it }
+    }
+
     if (isAccepted == null) {
         // DataStore value not read yet: show nothing instead of flashing content.
         Box(modifier = Modifier.fillMaxSize())
@@ -65,6 +97,17 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         AppLockScreen(onUnlocked = viewModel::markUnlocked)
     } else {
         val navController = rememberNavController()
+        LaunchedEffect(pendingNav) {
+            pendingNav?.let { (target, experienceId) ->
+                when (target) {
+                    NAV_QUICK_NOTE -> if (experienceId > 0) {
+                        navController.navigateToQuickTimedNote(experienceId)
+                    }
+                    NAV_TIME_CAPSULE -> navController.navigateToTimeCapsule()
+                }
+                pendingNav = null
+            }
+        }
         Scaffold(
             bottomBar = {
                 val isShowingBottomBar = isKeyboardOpen().value.not()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -32,8 +32,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -75,7 +77,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     var pendingNav by remember { mutableStateOf<Pair<String, Int>?>(null) }
     val activity = LocalContext.current as? androidx.activity.ComponentActivity
     DisposableEffect(activity) {
-        val listener = androidx.activity.OnNewIntentListener { intent ->
+        val listener = { intent: android.content.Intent ->
             parseNavIntent(intent)?.let { pendingNav = it }
             true
         }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/graphs/journalGraph.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/graphs/journalGraph.kt
@@ -29,6 +29,8 @@ import com.isaakhanimann.journal.ui.main.navigation.routers.NoArgumentRouter
 import com.isaakhanimann.journal.ui.main.navigation.routers.TabRouter
 import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToAddRating
 import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToAddTimedNote
+import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToQuickTimedNote
+import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToTimeCapsule
 import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToEditExperience
 import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToEditRating
 import com.isaakhanimann.journal.ui.main.navigation.routers.navigateToEditTimedNote
@@ -45,6 +47,8 @@ import com.isaakhanimann.journal.ui.tabs.journal.experience.editingestion.EditIn
 import com.isaakhanimann.journal.ui.tabs.journal.experience.rating.add.AddRatingScreen
 import com.isaakhanimann.journal.ui.tabs.journal.experience.rating.edit.EditRatingScreen
 import com.isaakhanimann.journal.ui.tabs.journal.experience.timednote.add.AddTimedNoteScreen
+import com.isaakhanimann.journal.ui.tabs.journal.experience.timednote.add.QuickTimedNoteScreen
+import com.isaakhanimann.journal.ui.tabs.journal.timecapsule.TimeCapsuleScreen
 import com.isaakhanimann.journal.ui.tabs.journal.experience.timednote.edit.EditTimedNoteScreen
 import com.isaakhanimann.journal.ui.tabs.journal.experience.timeline.ExplainTimelineScreen
 import com.isaakhanimann.journal.ui.tabs.journal.experience.timeline.screen.TimelineScreen
@@ -63,7 +67,8 @@ fun NavGraphBuilder.journalGraph(navController: NavController) {
             JournalScreen(
                 navigateToExperiencePopNothing = navController::navigateToExperience,
                 navigateToAddIngestion = navController::navigateToAddIngestion,
-                navigateToCalendar = navController::navigateToCalendar
+                navigateToCalendar = navController::navigateToCalendar,
+                navigateToQuickTimedNote = navController::navigateToQuickTimedNote
             )
         }
         composableWithTransitions(
@@ -83,6 +88,20 @@ fun NavGraphBuilder.journalGraph(navController: NavController) {
             arguments = ArgumentRouter.AddTimedNoteRouter.args
         ) {
             AddTimedNoteScreen(navigateBack = navController::popBackStack)
+        }
+        composableWithTransitions(
+            ArgumentRouter.QuickTimedNoteRouter.route,
+            arguments = ArgumentRouter.QuickTimedNoteRouter.args
+        ) {
+            QuickTimedNoteScreen(navigateBack = navController::popBackStack)
+        }
+        composableWithTransitions(
+            ArgumentRouter.TimeCapsuleRouter.route
+        ) {
+            TimeCapsuleScreen(
+                navigateBack = navController::popBackStack,
+                navigateToExperience = navController::navigateToExperience
+            )
         }
         composableWithTransitions(
             ArgumentRouter.EditRatingRouter.route,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
@@ -51,6 +51,8 @@ private const val ROUTE_START_CHOOSE_DOSE_CUSTOM_UNIT = "chooseDoseCustomUnit/"
 private const val ROUTE_START_EDIT_EXPERIENCE = "editExperience/"
 private const val ROUTE_START_ADD_RATING = "addRating/"
 private const val ROUTE_START_ADD_TIMED_NOTE = "addTimedNote/"
+private const val ROUTE_START_QUICK_TIMED_NOTE = "quickTimedNote/"
+private const val ROUTE_START_TIME_CAPSULE = "timeCapsule"
 private const val ROUTE_START_EDIT_RATING = "editRating/"
 private const val ROUTE_START_EDIT_TIMED_NOTE = "editTimedNote/"
 private const val ROUTE_START_EDIT_CUSTOM = "editCustom/"
@@ -104,6 +106,16 @@ sealed class ArgumentRouter(val route: String, val args: List<NamedNavArgument>)
     object AddTimedNoteRouter : ArgumentRouter(
         route = "$ROUTE_START_ADD_TIMED_NOTE{$EXPERIENCE_ID_KEY}",
         args = listOf(navArgument(EXPERIENCE_ID_KEY) { type = NavType.IntType })
+    )
+
+    object QuickTimedNoteRouter : ArgumentRouter(
+        route = "$ROUTE_START_QUICK_TIMED_NOTE{$EXPERIENCE_ID_KEY}",
+        args = listOf(navArgument(EXPERIENCE_ID_KEY) { type = NavType.IntType })
+    )
+
+    object TimeCapsuleRouter : ArgumentRouter(
+        route = ROUTE_START_TIME_CAPSULE,
+        args = emptyList()
     )
 
     object EditRatingRouter : ArgumentRouter(
@@ -265,6 +277,14 @@ fun NavController.navigateToAddRating(experienceId: Int) {
 
 fun NavController.navigateToAddTimedNote(experienceId: Int) {
     navigate(ROUTE_START_ADD_TIMED_NOTE + experienceId)
+}
+
+fun NavController.navigateToQuickTimedNote(experienceId: Int) {
+    navigate(ROUTE_START_QUICK_TIMED_NOTE + experienceId)
+}
+
+fun NavController.navigateToTimeCapsule() {
+    navigate(ROUTE_START_TIME_CAPSULE)
 }
 
 fun NavController.navigateToEditRating(ratingId: Int) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
@@ -27,7 +27,7 @@ class EffectNotificationReceiver : BroadcastReceiver() {
         val experienceId = intent.getIntExtra(EXTRA_EXPERIENCE_ID, -1)
         if (experienceId > 0) {
             NotificationManagerCompat.from(context)
-                .cancel(EFFECT_NOTIFICATION_ID_BASE + experienceId)
+                .cancel(Notifications.EFFECT_NOTIFICATION_ID_BASE + experienceId)
         }
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
@@ -111,6 +111,8 @@ object Notifications {
 
         val notification = NotificationCompat.Builder(context, CHANNEL_EFFECTS)
             .setSmallIcon(R.drawable.ic_notification)
+            // Substance names are sensitive: hide the content on the lock screen.
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             .setContentTitle(I18n.translate(context, "effect_notification_title"))
             .setContentText(text)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
@@ -1,0 +1,172 @@
+package com.isaakhanimann.journal.ui.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.isaakhanimann.journal.MainActivity
+import com.isaakhanimann.journal.R
+import com.isaakhanimann.journal.localization.I18n
+import java.time.Instant
+import java.time.ZoneId
+
+/** Intent extras used by notification taps to steer the app to a target screen. */
+const val EXTRA_NAVIGATE_TO = "navigateTo"
+const val EXTRA_EXPERIENCE_ID = "experienceId"
+const val NAV_QUICK_NOTE = "quick_note"
+const val NAV_TIME_CAPSULE = "time_capsule"
+
+/** Cancels the effect notification for an experience; used by the "End" action. */
+class EffectNotificationReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val experienceId = intent.getIntExtra(EXTRA_EXPERIENCE_ID, -1)
+        if (experienceId > 0) {
+            NotificationManagerCompat.from(context)
+                .cancel(EFFECT_NOTIFICATION_ID_BASE + experienceId)
+        }
+    }
+}
+
+/**
+ * Notification helpers: "active effects" notification (stays visible while effects
+ * last, with a quick-note action) and the "time capsule" daily reminder.
+ */
+object Notifications {
+
+    const val CHANNEL_EFFECTS = "effects"
+    const val CHANNEL_TIME_CAPSULE = "time_capsule"
+    private const val EFFECT_NOTIFICATION_ID_BASE = 1000
+    const val TIME_CAPSULE_NOTIFICATION_ID = 2001
+    private const val REQUEST_CODE_BASE = 3000
+
+    fun createChannels(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_EFFECTS,
+                I18n.translate(context, "effect_notification_channel"),
+                NotificationManager.IMPORTANCE_LOW
+            )
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_TIME_CAPSULE,
+                I18n.translate(context, "time_capsule_channel"),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+        )
+    }
+
+    fun hasNotificationPermission(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            NotificationManagerCompat.from(context).areNotificationsEnabled()
+
+    /**
+     * Shows (or refreshes) the "effects in progress" notification for an experience.
+     */
+    fun showEffectNotification(
+        context: Context,
+        experienceId: Int,
+        substanceName: String,
+        ingestionTime: Instant
+    ) {
+        if (!hasNotificationPermission(context)) return
+        val timeText = ingestionTime.atZone(ZoneId.systemDefault())
+            .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"))
+        val text = I18n.translate(
+            context,
+            "effect_notification_text",
+            mapOf("substance" to substanceName, "time" to timeText)
+        )
+
+        // Quick-note action: opens the app directly on the quick-note screen.
+        val noteIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(EXTRA_NAVIGATE_TO, NAV_QUICK_NOTE)
+            putExtra(EXTRA_EXPERIENCE_ID, experienceId)
+        }
+        val notePendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE_BASE + experienceId,
+            noteIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        // End action: cancels the notification via a broadcast receiver.
+        val stopIntent = Intent(context, EffectNotificationReceiver::class.java).apply {
+            putExtra(EXTRA_EXPERIENCE_ID, experienceId)
+        }
+        val stopPendingIntent = PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE_BASE + experienceId + 100,
+            stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_EFFECTS)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(I18n.translate(context, "effect_notification_title"))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setContentIntent(notePendingIntent)
+            .addAction(
+                0,
+                I18n.translate(context, "effect_notification_action_note"),
+                notePendingIntent
+            )
+            .addAction(
+                0,
+                I18n.translate(context, "effect_notification_action_stop"),
+                stopPendingIntent
+            )
+            .build()
+        NotificationManagerCompat.from(context)
+            .notify(EFFECT_NOTIFICATION_ID_BASE + experienceId, notification)
+    }
+
+    fun cancelEffectNotification(context: Context, experienceId: Int) {
+        NotificationManagerCompat.from(context)
+            .cancel(EFFECT_NOTIFICATION_ID_BASE + experienceId)
+    }
+
+    /**
+     * Shows the daily "time capsule" notification: something was recorded exactly
+     * one year ago today.
+     */
+    fun showTimeCapsuleNotification(context: Context, experienceCount: Int) {
+        if (!hasNotificationPermission(context)) return
+        val text = I18n.translate(
+            context,
+            "time_capsule_notification_text",
+            mapOf("count" to experienceCount.toString())
+        )
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(EXTRA_NAVIGATE_TO, NAV_TIME_CAPSULE)
+        }
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE_BASE + 200,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_TIME_CAPSULE)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(I18n.translate(context, "time_capsule_notification_title"))
+            .setContentText(text)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+            .setAutoCancel(true)
+            .setContentIntent(contentIntent)
+            .build()
+        NotificationManagerCompat.from(context)
+            .notify(TIME_CAPSULE_NOTIFICATION_ID, notification)
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
@@ -40,7 +40,7 @@ object Notifications {
 
     const val CHANNEL_EFFECTS = "effects"
     const val CHANNEL_TIME_CAPSULE = "time_capsule"
-    private const val EFFECT_NOTIFICATION_ID_BASE = 1000
+    const val EFFECT_NOTIFICATION_ID_BASE = 1000
     const val TIME_CAPSULE_NOTIFICATION_ID = 2001
     private const val REQUEST_CODE_BASE = 3000
 

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/TimeCapsuleWorker.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/TimeCapsuleWorker.kt
@@ -1,0 +1,43 @@
+package com.isaakhanimann.journal.ui.notifications
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Daily check: if anything was recorded exactly one year ago today, post the
+ * "time capsule" notification. Idempotent (fixed notification id, one per day).
+ */
+@HiltWorker
+class TimeCapsuleWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val experienceRepo: ExperienceRepository
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val lastYear = LocalDate.now().minusYears(1)
+            val from = lastYear.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()
+            val to = from.plus(1, ChronoUnit.DAYS)
+            val experiences =
+                experienceRepo.getExperiencesWithIngestionsTimedNotesAndRatingsInRange(from, to)
+            if (experiences.isNotEmpty()) {
+                Notifications.showTimeCapsuleNotification(
+                    applicationContext,
+                    experiences.size
+                )
+            }
+            Result.success()
+        } catch (e: Exception) {
+            Result.retry()
+        }
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -75,6 +75,7 @@ fun JournalScreen(
     navigateToExperiencePopNothing: (experienceId: Int) -> Unit,
     navigateToAddIngestion: () -> Unit,
     navigateToCalendar: () -> Unit,
+    navigateToQuickTimedNote: (experienceId: Int) -> Unit,
     viewModel: JournalViewModel = hiltViewModel()
 ) {
     val experiences = viewModel.experiences.collectAsState().value
@@ -108,7 +109,8 @@ fun JournalScreen(
         onChangeIsSearchEnabled = viewModel::onChangeOfIsSearchEnabled,
         experiences = experiences,
         substanceRepository = viewModel.substanceRepository,
-        ownerUserName = ownerUserName
+        ownerUserName = ownerUserName,
+        navigateToQuickTimedNote = navigateToQuickTimedNote
     )
 }
 
@@ -128,8 +130,12 @@ fun JournalScreen(
     onChangeIsSearchEnabled: (Boolean) -> Unit,
     experiences: List<ExperienceWithIngestionsCompanionsAndRatings>,
     substanceRepository: SubstanceRepository,
-    ownerUserName: String
+    ownerUserName: String,
+    navigateToQuickTimedNote: (experienceId: Int) -> Unit = {}
 ) {
+    val latestExperienceId = experiences
+        .firstOrNull { it.ingestions.isNotEmpty() }
+        ?.experience?.id
     Scaffold(
         topBar = {
             TopAppBar(
@@ -148,6 +154,14 @@ fun JournalScreen(
                             Icon(
                                 Icons.Outlined.Timer,
                                 contentDescription = i18n("journal_time_relative_to_now")
+                            )
+                        }
+                    }
+                    if (latestExperienceId != null) {
+                        IconButton(onClick = { navigateToQuickTimedNote(latestExperienceId) }) {
+                            Icon(
+                                Icons.Outlined.EditNote,
+                                contentDescription = i18n("quick_note_title")
                             )
                         }
                     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.outlined.EditNote
 import androidx.compose.material.icons.outlined.SearchOff
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material.icons.outlined.Timer
@@ -134,7 +135,7 @@ fun JournalScreen(
     navigateToQuickTimedNote: (experienceId: Int) -> Unit = {}
 ) {
     val latestExperienceId = experiences
-        .firstOrNull { it.ingestions.isNotEmpty() }
+        .firstOrNull { it.ingestionsWithCompanions.isNotEmpty() }
         ?.experience?.id
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeViewModel.kt
@@ -18,6 +18,7 @@
 
 package com.isaakhanimann.journal.ui.tabs.journal.addingestion.time
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -39,10 +40,12 @@ import com.isaakhanimann.journal.ui.main.navigation.routers.ESTIMATED_DOSE_STAND
 import com.isaakhanimann.journal.ui.main.navigation.routers.IS_ESTIMATE_KEY
 import com.isaakhanimann.journal.ui.main.navigation.routers.SUBSTANCE_NAME_KEY
 import com.isaakhanimann.journal.ui.main.navigation.routers.UNITS_KEY
+import com.isaakhanimann.journal.ui.notifications.Notifications
 import com.isaakhanimann.journal.ui.tabs.settings.combinations.UserPreferences
 import com.isaakhanimann.journal.ui.utils.getInstant
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -67,6 +70,7 @@ const val hourLimitToSeparateIngestions: Long = 12
 class ChooseTimeViewModel @Inject constructor(
     private val experienceRepo: ExperienceRepository,
     private val userPreferences: UserPreferences,
+    @ApplicationContext private val appContext: Context,
     state: SavedStateHandle
 ) : ViewModel() {
     var substanceName by mutableStateOf("")
@@ -260,6 +264,7 @@ class ChooseTimeViewModel @Inject constructor(
             color = selectedColor
         )
         val ingestionTime = localDateTimeFlow.first().atZone(ZoneId.systemDefault()).toInstant()
+        val savedExperienceId: Int
         if (userWantsToCreateANewExperience || oldIdToUse == null) {
             val newExperience = Experience(
                 id = newIdToUse,
@@ -275,11 +280,23 @@ class ChooseTimeViewModel @Inject constructor(
                 experience = newExperience,
                 substanceCompanion = substanceCompanion
             )
+            savedExperienceId = newExperience.id
         } else {
             val newIngestion = createNewIngestion(oldIdToUse)
             experienceRepo.insertIngestionAndCompanion(
                 ingestion = newIngestion,
                 substanceCompanion = substanceCompanion
+            )
+            savedExperienceId = oldIdToUse
+        }
+        // Keep a lightweight "effects in progress" notification with a quick-note
+        // action so notes can be added from any other app while effects last.
+        if (userPreferences.isEffectNotificationEnabledFlow.first()) {
+            Notifications.showEffectNotification(
+                context = appContext,
+                experienceId = savedExperienceId,
+                substanceName = substanceName,
+                ingestionTime = ingestionTime
             )
         }
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/OneExperienceViewModel.kt
@@ -18,6 +18,7 @@
 
 package com.isaakhanimann.journal.ui.tabs.journal.experience
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -27,6 +28,7 @@ import com.isaakhanimann.journal.data.substances.classes.roa.RoaDose
 import com.isaakhanimann.journal.data.substances.classes.roa.RoaDuration
 import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepository
 import com.isaakhanimann.journal.ui.main.navigation.routers.EXPERIENCE_ID_KEY
+import com.isaakhanimann.journal.ui.notifications.Notifications
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.interactions.InteractionChecker
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.time.hourLimitToSeparateIngestions
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.SavedTimeDisplayOption
@@ -39,6 +41,7 @@ import com.isaakhanimann.journal.ui.tabs.journal.experience.models.InteractionEx
 import com.isaakhanimann.journal.ui.tabs.settings.combinations.CombinationSettingsStorage
 import com.isaakhanimann.journal.ui.tabs.settings.combinations.UserPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
@@ -61,6 +64,7 @@ class OneExperienceViewModel @Inject constructor(
     val substanceRepo: SubstanceRepository,
     private val interactionChecker: InteractionChecker,
     private val userPreferences: UserPreferences,
+    @ApplicationContext private val appContext: Context,
     combinationSettingsStorage: CombinationSettingsStorage,
     state: SavedStateHandle
 ) : ViewModel() {
@@ -354,6 +358,8 @@ class OneExperienceViewModel @Inject constructor(
     fun deleteExperience() {
         viewModelScope.launch {
             experienceRepo.deleteEverythingOfExperience(experienceId = experienceId)
+            // The 'effects in progress' notification must not outlive its experience.
+            Notifications.cancelEffectNotification(appContext, experienceId)
         }
     }
 

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.runtime.FocusRequester
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.isaakhanimann.journal.localization.i18n
 

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.FocusRequester
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteScreen.kt
@@ -1,0 +1,67 @@
+package com.isaakhanimann.journal.ui.tabs.journal.experience.timednote.add
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.FocusRequester
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRequester
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.isaakhanimann.journal.localization.i18n
+
+/**
+ * One-tap timed note entry: a single focused text field and a done button.
+ * The note is stamped with the current time and attached to the experience
+ * passed via the route (from the effect notification or the journal bar).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickTimedNoteScreen(
+    viewModel: QuickTimedNoteViewModel = hiltViewModel(),
+    navigateBack: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(i18n("quick_note_title")) },
+                actions = {
+                    IconButton(onClick = {
+                        viewModel.onDoneTap()
+                        navigateBack()
+                    }) {
+                        Icon(
+                            Icons.Filled.Done,
+                            contentDescription = i18n("common_done")
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        TextField(
+            value = viewModel.note,
+            onValueChange = viewModel::onChangeNote,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+                .focusRequester(focusRequester),
+            placeholder = { Text(i18n("quick_note_hint")) }
+        )
+    }
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteViewModel.kt
@@ -26,18 +26,21 @@ class QuickTimedNoteViewModel @Inject constructor(
 ) : ViewModel() {
     var note by mutableStateOf("")
         private set
-    val experienceId = state.get<Int>(EXPERIENCE_ID_KEY)!!
+    // Null-safe: a missing/unsurvivable navigation argument must not crash the app
+    // (e.g. process death while the route was being rebuilt).
+    val experienceId: Int? = state.get<Int>(EXPERIENCE_ID_KEY)
 
     fun onChangeNote(newNote: String) {
         note = newNote
     }
 
     fun onDoneTap() {
+        val targetExperienceId = experienceId ?: return
         if (note.isBlank()) return
         val newTimedNote = TimedNote(
             time = Instant.now(),
             creationDate = Instant.now(),
-            experienceId = experienceId,
+            experienceId = targetExperienceId,
             isPartOfTimeline = true,
             color = AdaptiveColor.BLUE,
             note = note.trim()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timednote/add/QuickTimedNoteViewModel.kt
@@ -1,0 +1,49 @@
+package com.isaakhanimann.journal.ui.tabs.journal.experience.timednote.add
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
+import com.isaakhanimann.journal.data.room.experiences.entities.TimedNote
+import com.isaakhanimann.journal.ui.main.navigation.routers.EXPERIENCE_ID_KEY
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.Instant
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+/**
+ * Minimal timed-note entry: current time, default color, on the timeline,
+ * attached to the experience from the route. Zero configuration, one tap.
+ */
+@HiltViewModel
+class QuickTimedNoteViewModel @Inject constructor(
+    private val experienceRepo: ExperienceRepository,
+    state: SavedStateHandle
+) : ViewModel() {
+    var note by mutableStateOf("")
+        private set
+    val experienceId = state.get<Int>(EXPERIENCE_ID_KEY)!!
+
+    fun onChangeNote(newNote: String) {
+        note = newNote
+    }
+
+    fun onDoneTap() {
+        if (note.isBlank()) return
+        val newTimedNote = TimedNote(
+            time = Instant.now(),
+            creationDate = Instant.now(),
+            experienceId = experienceId,
+            isPartOfTimeline = true,
+            color = AdaptiveColor.BLUE,
+            note = note.trim()
+        )
+        viewModelScope.launch {
+            experienceRepo.insert(timedNote = newTimedNote)
+        }
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
@@ -64,7 +64,15 @@ fun TimeCapsuleScreen(
         }
     ) { padding ->
         if (isLoading) {
-            // brief loading; list is small, resolves within a frame or two
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+                horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally
+            ) {
+                androidx.compose.material3.CircularProgressIndicator()
+            }
         } else if (experiences.isEmpty()) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
@@ -93,7 +93,7 @@ fun TimeCapsuleScreen(
             LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
                 items(experiences, key = { it.experience.id }) { item ->
                     val substanceNames = item.ingestions
-                        .map { it.ingestion.substanceName }
+                        .map { it.substanceName }
                         .distinct()
                         .joinToString(", ")
                     Column(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
@@ -1,0 +1,126 @@
+package com.isaakhanimann.journal.ui.tabs.journal.timecapsule
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsTimedNotesAndRatings
+import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+
+/**
+ * "This day last year" recap: the experiences recorded exactly one year ago.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimeCapsuleScreen(
+    viewModel: TimeCapsuleViewModel = hiltViewModel(),
+    navigateBack: () -> Unit,
+    navigateToExperience: (experienceId: Int) -> Unit
+) {
+    var experiences by remember { mutableStateOf<List<ExperienceWithIngestionsTimedNotesAndRatings>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    LaunchedEffect(Unit) {
+        experiences = viewModel.loadLastYearExperiences()
+        isLoading = false
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(i18n("time_capsule_screen_title")) },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = i18n("common_back")
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (isLoading) {
+            // brief loading; list is small, resolves within a frame or two
+        } else if (experiences.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+            ) {
+                Text(
+                    text = i18n("time_capsule_empty"),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+                items(experiences, key = { it.experience.id }) { item ->
+                    val substanceNames = item.ingestions
+                        .map { it.ingestion.substanceName }
+                        .distinct()
+                        .joinToString(", ")
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { navigateToExperience(item.experience.id) }
+                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                    ) {
+                        Text(
+                            text = item.experience.sortDate.getStringOfPattern("HH:mm"),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = item.experience.title.ifBlank { i18n("common_untitled") },
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        if (substanceNames.isNotBlank()) {
+                            Text(
+                                text = substanceNames,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                        if (item.timedNotes.isNotEmpty()) {
+                            Text(
+                                text = item.timedNotes.first().note,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2
+                            )
+                        }
+                    }
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleViewModel.kt
@@ -1,0 +1,27 @@
+package com.isaakhanimann.journal.ui.tabs.journal.timecapsule
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsTimedNotesAndRatings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@HiltViewModel
+class TimeCapsuleViewModel @Inject constructor(
+    private val experienceRepo: ExperienceRepository
+) : ViewModel() {
+
+    suspend fun loadLastYearExperiences(): List<ExperienceWithIngestionsTimedNotesAndRatings> =
+        withContext(Dispatchers.IO) {
+            val lastYear = LocalDate.now().minusYears(1)
+            val from = lastYear.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()
+            val to = from.plus(1, ChronoUnit.DAYS)
+            experienceRepo.getExperiencesWithIngestionsTimedNotesAndRatingsInRange(from, to)
+        }
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ package com.isaakhanimann.journal.ui.tabs.settings
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -138,6 +139,8 @@ fun SettingsScreen(
         saveOpenLinkInBrowser = viewModel::saveOpenLinkInBrowser,
         isAppLockEnabled = viewModel.isAppLockEnabledFlow.collectAsState().value,
         saveAppLockEnabled = viewModel::saveAppLockEnabled,
+        isEffectNotificationEnabled = viewModel.isEffectNotificationEnabledFlow.collectAsState().value,
+        saveEffectNotificationEnabled = viewModel::saveEffectNotificationEnabled,
         supportedLanguages = supportedLanguages,
         selectedLanguageKey = selectedLanguageKey,
         saveSelectedLanguage = viewModel::saveSelectedLanguage,
@@ -168,6 +171,8 @@ fun SettingsScreen(
     saveOpenLinkInBrowser: (Boolean) -> Unit,
     isAppLockEnabled: Boolean,
     saveAppLockEnabled: (Boolean) -> Unit,
+    isEffectNotificationEnabled: Boolean,
+    saveEffectNotificationEnabled: (Boolean) -> Unit,
     supportedLanguages: Map<String, String>,
     selectedLanguageKey: String?,
     saveSelectedLanguage: (String?) -> Unit,
@@ -304,6 +309,39 @@ fun SettingsScreen(
                             onCheckedChange = saveAppLockEnabled
                         )
                     }
+                }
+                HorizontalDivider()
+                val permissionLauncher = rememberLauncherForActivityResult(
+                    contract = ActivityResultContracts.RequestPermission()
+                ) { granted ->
+                    if (!granted) {
+                        saveEffectNotificationEnabled(false)
+                    }
+                }
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = horizontalPadding, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = i18n("settings_effect_notification"))
+                        Text(
+                            text = i18n("settings_effect_notification_description"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = isEffectNotificationEnabled,
+                        onCheckedChange = { enabled ->
+                            saveEffectNotificationEnabled(enabled)
+                            if (enabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                permissionLauncher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
+                            }
+                        }
+                    )
                 }
             }
 

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
@@ -76,6 +76,18 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    val isEffectNotificationEnabledFlow = userPreferences.isEffectNotificationEnabledFlow.stateIn(
+        initialValue = true,
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
+
+    fun saveEffectNotificationEnabled(value: Boolean) {
+        viewModelScope.launch {
+            userPreferences.saveEffectNotificationEnabled(value)
+        }
+    }
+
     val isOpenLinkInBrowserFlow = userPreferences.isOpenLinkInBrowserFlow.stateIn(
         initialValue = false,
         scope = viewModelScope,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -40,6 +40,7 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         val KEY_OWNER_USER_NAME = stringPreferencesKey("key_owner_user_name")
         val KEY_OWNER_USER_ACHIEVEMENT = stringPreferencesKey("key_owner_user_achievement") // registerName;
         val KEY_APP_LOCK_ENABLED = booleanPreferencesKey("key_app_lock_enabled")
+        val KEY_EFFECT_NOTIFICATION_ENABLED = booleanPreferencesKey("key_effect_notification_enabled")
     }
 
     suspend fun saveTimeDisplayOption(value: SavedTimeDisplayOption) {
@@ -130,6 +131,17 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         .map { preferences ->
             preferences[PreferencesKeys.KEY_APP_LOCK_ENABLED] ?: false
         }
+
+    val isEffectNotificationEnabledFlow: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.KEY_EFFECT_NOTIFICATION_ENABLED] ?: true
+        }
+
+    suspend fun saveEffectNotificationEnabled(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.KEY_EFFECT_NOTIFICATION_ENABLED] = value
+        }
+    }
 
     suspend fun saveAppLockEnabled(value: Boolean) {
         dataStore.edit { preferences ->

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
@@ -48,11 +48,13 @@ fun StatsReportCard(statsModel: StatsModel) {
         // isSystemInDarkTheme() from LocalConfiguration, which would otherwise
         // draw dark-theme ticks on the light card when the system is in dark mode.
         val configuration = LocalConfiguration.current
+        // Configuration.copy() is API 33+; use the copy constructor (API 1) instead.
+        val dayModeConfiguration = Configuration(configuration).apply {
+            uiMode = (uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                Configuration.UI_MODE_NIGHT_NO
+        }
         CompositionLocalProvider(
-            LocalConfiguration provides configuration.copy(
-                uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
-                    Configuration.UI_MODE_NIGHT_NO
-            )
+            LocalConfiguration provides dayModeConfiguration
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
@@ -16,12 +16,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.lightColorScheme
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -37,19 +40,33 @@ import java.time.Instant
  */
 @Composable
 fun StatsReportCard(statsModel: StatsModel) {
+    // The off-screen renderer measures the content with an EXACT width constraint
+    // (e.g. 1080px), so the card fills the container instead of declaring its own
+    // width in dp — dp would be scaled by density and overflow the constraint.
     MaterialTheme(colorScheme = lightColorScheme()) {
-        Column(
-            modifier = Modifier
-                .width(1080.dp)
-                .background(MaterialTheme.colorScheme.background)
-                .padding(36.dp),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+        // Force the day uiMode for the whole subtree: BarChart reads
+        // isSystemInDarkTheme() from LocalConfiguration, which would otherwise
+        // draw dark-theme ticks on the light card when the system is in dark mode.
+        val configuration = LocalConfiguration.current
+        CompositionLocalProvider(
+            LocalConfiguration provides configuration.copy(
+                uiMode = (configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or
+                    Configuration.UI_MODE_NIGHT_NO
+            )
         ) {
-            ReportHeader(statsModel)
-            ReportNumbers(statsModel)
-            ReportTrend(statsModel)
-            ReportTopSubstances(statsModel)
-            ReportFooter()
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(36.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                ReportHeader(statsModel)
+                ReportNumbers(statsModel)
+                ReportTrend(statsModel)
+                ReportTopSubstances(statsModel)
+                ReportFooter()
+            }
         }
     }
 }
@@ -122,9 +139,10 @@ private fun NumberCard(value: Int, label: String, modifier: Modifier = Modifier)
         ) {
             Text(
                 text = value.toString(),
-                style = MaterialTheme.typography.headlineLarge,
+                style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1
             )
             Text(
                 text = label,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsReportCard.kt
@@ -1,0 +1,239 @@
+package com.isaakhanimann.journal.ui.tabs.stats
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.localization.i18nOrDefault
+import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import java.time.Instant
+
+/**
+ * A polished, fixed-width (1080px) stats report card rendered for sharing.
+ * Always drawn in the light color scheme so the shared image looks the same
+ * regardless of the app's dark-mode setting.
+ */
+@Composable
+fun StatsReportCard(statsModel: StatsModel) {
+    MaterialTheme(colorScheme = lightColorScheme()) {
+        Column(
+            modifier = Modifier
+                .width(1080.dp)
+                .background(MaterialTheme.colorScheme.background)
+                .padding(36.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            ReportHeader(statsModel)
+            ReportNumbers(statsModel)
+            ReportTrend(statsModel)
+            ReportTopSubstances(statsModel)
+            ReportFooter()
+        }
+    }
+}
+
+@Composable
+private fun ReportHeader(statsModel: StatsModel) {
+    val periodText = i18nOrDefault(
+        "stats_report_period_${statsModel.selectedOption.name.lowercase()}",
+        statsModel.selectedOption.longDisplayText
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(28.dp))
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.tertiary
+                    )
+                )
+            )
+            .padding(horizontal = 32.dp, vertical = 28.dp)
+    ) {
+        Column {
+            Text(
+                text = i18n("stats_report_title"),
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "$periodText · ${statsModel.startDateText}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.9f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReportNumbers(statsModel: StatsModel) {
+    val records = statsModel.statItems.sumOf { it.ingestionCount }
+    val experiences = statsModel.statItems.sumOf { it.experienceCount }
+    val substances = statsModel.statItems.size
+    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        NumberCard(value = records, label = i18n("stats_report_records"), Modifier.weight(1f))
+        NumberCard(
+            value = experiences,
+            label = i18n("stats_report_experiences"),
+            Modifier.weight(1f)
+        )
+        NumberCard(value = substances, label = i18n("stats_report_substances"), Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun NumberCard(value: Int, label: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 18.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = value.toString(),
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReportTrend(statsModel: StatsModel) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+    ) {
+        Column(modifier = Modifier.padding(vertical = 16.dp)) {
+            Text(
+                text = i18n("stats_report_trend"),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 6.dp)
+            )
+            BarChart(
+                buckets = statsModel.chartBuckets,
+                startDateText = statsModel.startDateText
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReportTopSubstances(statsModel: StatsModel) {
+    val top = statsModel.statItems
+        .sortedByDescending { it.ingestionCount }
+        .take(5)
+    if (top.isEmpty()) return
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+            Text(
+                text = i18n("stats_report_top"),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+            val maxCount = top.maxOf { it.ingestionCount }.coerceAtLeast(1)
+            top.forEachIndexed { index, item ->
+                if (index > 0) Spacer(modifier = Modifier.height(14.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(16.dp)
+                            .clip(RoundedCornerShape(5.dp))
+                            .background(item.color.getComposeColor(isDarkTheme = false))
+                    )
+                    Spacer(modifier = Modifier.width(14.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = item.substanceRepo?.getDisplayName(item.substanceName)
+                                ?: item.substanceName,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(6.dp)
+                                .clip(RoundedCornerShape(3.dp))
+                                .background(
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                                )
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(
+                                        item.ingestionCount.toFloat() / maxCount
+                                    )
+                                    .height(6.dp)
+                                    .clip(RoundedCornerShape(3.dp))
+                                    .background(MaterialTheme.colorScheme.primary)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(
+                        text = "${item.ingestionCount}×",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReportFooter() {
+    Text(
+        text = i18n(
+            "stats_report_generated",
+            mapOf("date" to Instant.now().getStringOfPattern("dd MMM yyyy"))
+        ),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
@@ -80,7 +80,6 @@ import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.tabs.settings.AvatarUtil
-import com.isaakhanimann.journal.ui.theme.JournalTheme
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.administrationRouteKey
 import com.isaakhanimann.journal.ui.utils.renderComposeViewToBitmap
@@ -115,33 +114,9 @@ fun StatsScreen(
     val currentView = LocalView.current
     val coroutineScope = rememberCoroutineScope()
     var isSharing by remember { mutableStateOf(false) }
-    val widthPx = (LocalConfiguration.current.screenWidthDp * LocalDensity.current.density).toInt()
+    val widthPx = 1080
     val shareStatsContent: @Composable () -> Unit = {
-        JournalTheme {
-            Surface(color = MaterialTheme.colorScheme.background) {
-                Column(
-                    modifier = Modifier.padding(vertical = 12.dp)
-                ) {
-                    Text(
-                        text = i18n(
-                            "stats_experiences_since",
-                            replacements = mapOf("date" to statsModel.startDateText)
-                        ),
-                        style = MaterialTheme.typography.titleMedium,
-                        modifier = Modifier.padding(start = 10.dp, top = 5.dp)
-                    )
-                    Text(
-                        text = i18n("stats_substance_counted_once"),
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(start = 10.dp, bottom = 10.dp)
-                    )
-                    BarChart(
-                        buckets = statsModel.chartBuckets,
-                        startDateText = statsModel.startDateText
-                    )
-                }
-            }
-        }
+        StatsReportCard(statsModel = statsModel)
     }
     Scaffold(
         topBar = {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
@@ -80,6 +80,7 @@ import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.tabs.settings.AvatarUtil
+import com.isaakhanimann.journal.ui.theme.JournalTheme
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.administrationRouteKey
 import com.isaakhanimann.journal.ui.utils.renderComposeViewToBitmap
@@ -114,9 +115,33 @@ fun StatsScreen(
     val currentView = LocalView.current
     val coroutineScope = rememberCoroutineScope()
     var isSharing by remember { mutableStateOf(false) }
-    val widthPx = 1080
+    val widthPx = (LocalConfiguration.current.screenWidthDp * LocalDensity.current.density).toInt()
     val shareStatsContent: @Composable () -> Unit = {
-        StatsReportCard(statsModel = statsModel)
+        JournalTheme {
+            Surface(color = MaterialTheme.colorScheme.background) {
+                Column(
+                    modifier = Modifier.padding(vertical = 12.dp)
+                ) {
+                    Text(
+                        text = i18n(
+                            "stats_experiences_since",
+                            replacements = mapOf("date" to statsModel.startDateText)
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(start = 10.dp, top = 5.dp)
+                    )
+                    Text(
+                        text = i18n("stats_substance_counted_once"),
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(start = 10.dp, bottom = 10.dp)
+                    )
+                    BarChart(
+                        buckets = statsModel.chartBuckets,
+                        startDateText = statsModel.startDateText
+                    )
+                }
+            }
+        }
     }
     Scaffold(
         topBar = {

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Monochrome notification small icon: a simple open-eye outline (alpha-only). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z" />
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ hiltNavigationCompose = "1.4.0"
 datastore = "1.2.1"
 splashscreen = "1.2.0"
 biometric = "1.1.0"
+work = "2.10.0"
 
 # 第三方库
 accompanist = "0.36.0"
@@ -82,6 +83,8 @@ hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", ve
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 androidx-hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "androidxHilt" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidxHilt" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHilt" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 
 # Room
@@ -112,6 +115,7 @@ towdium-pinin = { module = "com.github.Towdium:PinIn", version.ref = "pinIn" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidxbrowser" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
+androidx-work = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 
 # 测试库
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
- Quick note: one-tap timed-note entry (focused text field, current time),
  reachable from the journal bar and from the effect notification
- Effect notification: after saving an ingestion, an ongoing notification
  stays while effects last with 'Add note' (deep-links to quick note) and
  'End effects' actions; toggle in settings (default on, POST_NOTIFICATIONS
  runtime permission on API 33+)
- Time capsule: daily WorkManager check posts 'this day last year' recap
  notification when experiences exist 365 days earlier; tap opens the recap
  screen (experiences, substances, first note)
- Intent routing: notification taps survive the accept/lock gate and navigate
  after unlock (quick note / time capsule)
- Infra: notification channels, hilt-work, range DAO query, i18n keys x3