### PR TITLE
feat: localize substance titles in add-ingestion and custom-unit flows

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -610,5 +610,7 @@
   "stats_report_period_days_30": "Last 30 days",
   "stats_report_period_weeks_26": "Last 6 months",
   "stats_report_period_months_12": "Last 12 months",
-  "stats_report_period_years_10": "Last 10 years"
+  "stats_report_period_years_10": "Last 10 years",
+  "choose_time_color_title": "{substance} color",
+  "custom_unit_title": "{substance} unit"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -610,5 +610,7 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 个月",
   "stats_report_period_months_12": "最近 12 个月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "choose_time_color_title": "{substance} 颜色",
+  "custom_unit_title": "{substance} 单位"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -610,5 +610,7 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 個月",
   "stats_report_period_months_12": "最近 12 個月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "choose_time_color_title": "{substance} 顏色",
+  "custom_unit_title": "{substance} 單位"
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseScreen.kt
@@ -94,6 +94,7 @@ fun ChooseDoseScreen(
         navigateToVolumetricDosingScreen = navigateToVolumetricDosingScreenOnJournalTab,
         navigateToSaferSniffingScreen = navigateToSaferSniffingScreen,
         substanceName = viewModel.substance.name,
+        getSubstanceDisplayName = viewModel.repository::getDisplayName,
         roaDose = viewModel.roaDose,
         administrationRoute = viewModel.administrationRoute,
         doseText = viewModel.doseText,
@@ -205,6 +206,7 @@ fun ChooseDoseScreen(
     navigateToSaferSniffingScreen: () -> Unit,
     navigateToURL: (url: String) -> Unit,
     substanceName: String,
+    getSubstanceDisplayName: (String) -> String = { it },
     roaDose: RoaDose?,
     administrationRoute: AdministrationRoute,
     doseRemark: String?,
@@ -237,7 +239,10 @@ fun ChooseDoseScreen(
                     Text(
                         i18n(
                             "dose_title_with_route",
-                            mapOf("substance" to substanceName, "route" to routeName)
+                            mapOf(
+                                "substance" to getSubstanceDisplayName(substanceName),
+                                "route" to routeName
+                            )
                         )
                     )
                 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseViewModel.kt
@@ -36,7 +36,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ChooseDoseViewModel @Inject constructor(
-    repository: SubstanceRepository,
+    val repository: SubstanceRepository,
     state: SavedStateHandle
 ) : ViewModel() {
     val substance: Substance

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/customunit/ChooseDoseCustomUnitScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/customunit/ChooseDoseCustomUnitScreen.kt
@@ -120,7 +120,8 @@ fun ChooseDoseCustomUnitScreen(
                 )
             },
             currentDoseClass = viewModel.currentDoseClass,
-            customUnitCalculationText = viewModel.customUnitCalculationText
+            customUnitCalculationText = viewModel.customUnitCalculationText,
+            getSubstanceDisplayName = viewModel.substanceRepo::getDisplayName
         )
     }
 }
@@ -179,11 +180,18 @@ fun ChooseDoseCustomUnitScreen(
     navigateToNext: () -> Unit,
     useUnknownDoseAndNavigate: () -> Unit,
     currentDoseClass: DoseClass?,
-    customUnitCalculationText: String?
+    customUnitCalculationText: String?,
+    getSubstanceDisplayName: (String) -> String = { it }
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text("${customUnit.substanceName} (${customUnit.name})") })
+            TopAppBar(
+                title = {
+                    Text(
+                        "${getSubstanceDisplayName(customUnit.substanceName)} (${customUnit.name})"
+                    )
+                }
+            )
         },
         floatingActionButton = {
             if (isValidDose) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeScreen.kt
@@ -111,6 +111,7 @@ fun ChooseTimeScreen(
         check = viewModel::toggleCheck,
         isChecked = viewModel.userWantsToContinueSameExperienceFlow.collectAsState().value,
         substanceName = viewModel.substanceName,
+        getSubstanceDisplayName = viewModel.substanceRepo::getDisplayName,
         enteredTitle = viewModel.enteredTitle,
         onChangeOfEnteredTitle = viewModel::changeTitle,
         isEnteredTitleOk = viewModel.isEnteredTitleOk,
@@ -176,6 +177,7 @@ fun ChooseTimeScreen(
     check: (Boolean) -> Unit,
     isChecked: Boolean,
     substanceName: String,
+    getSubstanceDisplayName: (String) -> String = { it },
     enteredTitle: String,
     onChangeOfEnteredTitle: (String) -> Unit,
     isEnteredTitleOk: Boolean,
@@ -192,7 +194,7 @@ fun ChooseTimeScreen(
                     i18n(
                         "substances_ingestion",
                         replacements = mapOf(
-                            "substance" to "$substanceName"
+                            "substance" to getSubstanceDisplayName(substanceName)
                         )
                     )
                 )
@@ -442,7 +444,10 @@ fun ChooseTimeScreen(
                 }
                 if (isShowingColorPicker) {
                     CardWithTitle(
-                        title = "$substanceName color",
+                        title = i18n(
+                            "choose_time_color_title",
+                            mapOf("substance" to getSubstanceDisplayName(substanceName))
+                        ),
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         ColorPicker(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/ChooseTimeViewModel.kt
@@ -32,6 +32,7 @@ import com.isaakhanimann.journal.data.room.experiences.entities.Ingestion
 import com.isaakhanimann.journal.data.room.experiences.entities.SubstanceCompanion
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestions
 import com.isaakhanimann.journal.data.substances.AdministrationRoute
+import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepository
 import com.isaakhanimann.journal.ui.main.navigation.routers.ADMINISTRATION_ROUTE_KEY
 import com.isaakhanimann.journal.ui.main.navigation.routers.CUSTOM_SUBSTANCE_ID_KEY
 import com.isaakhanimann.journal.ui.main.navigation.routers.CUSTOM_UNIT_ID_KEY
@@ -71,6 +72,7 @@ class ChooseTimeViewModel @Inject constructor(
     private val experienceRepo: ExperienceRepository,
     private val userPreferences: UserPreferences,
     @ApplicationContext private val appContext: Context,
+    val substanceRepo: SubstanceRepository,
     state: SavedStateHandle
 ) : ViewModel() {
     var substanceName by mutableStateOf("")

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/add/ChooseRouteDuringAddCustomUnitScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/add/ChooseRouteDuringAddCustomUnitScreen.kt
@@ -50,7 +50,9 @@ fun ChooseRouteDuringAddCustomUnitScreen(
                         i18n(
                             "substances_route",
                             replacements = mapOf(
-                                "substance" to "${viewModel.substanceName}"
+                                "substance" to viewModel.substanceRepo.getDisplayName(
+                                    viewModel.substanceName
+                                )
                             )
                         )
                     )

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/add/FinishAddCustomUnitScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/add/FinishAddCustomUnitScreen.kt
@@ -71,6 +71,7 @@ fun FinishAddCustomUnitScreen(
 ) {
     FinishAddCustomUnitScreenContent(
         substanceName = viewModel.substanceName,
+        getSubstanceDisplayName = viewModel.substanceRepository::getDisplayName,
         roaDose = viewModel.roaDose,
         dismiss = {
             viewModel.createSaveAndDismissAfter(dismiss = dismissAddCustomUnit)
@@ -130,6 +131,7 @@ private fun FinishAddCustomUnitScreenPreview(
 @Composable
 private fun FinishAddCustomUnitScreenContent(
     substanceName: String,
+    getSubstanceDisplayName: (String) -> String = { it },
     roaDose: RoaDose?,
     dismiss: () -> Unit,
     name: String,
@@ -152,7 +154,13 @@ private fun FinishAddCustomUnitScreenContent(
     onChangeOfIsArchived: (Boolean) -> Unit
 ) {
     Scaffold(
-        topBar = { TopAppBar(title = { Text("$substanceName unit") }) },
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(i18n("custom_unit_title", mapOf("substance" to getSubstanceDisplayName(substanceName))))
+                }
+            )
+        },
         floatingActionButton = {
             FloatingDoneButton {
                 dismiss()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/edit/EditCustomUnitScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/customunits/edit/EditCustomUnitScreen.kt
@@ -51,6 +51,7 @@ fun EditCustomUnitScreen(
 ) {
     EditCustomUnitScreenContent(
         substanceName = viewModel.substanceName,
+        getSubstanceDisplayName = viewModel.substanceRepository::getDisplayName,
         roaDose = viewModel.roaDose,
         dismiss = {
             viewModel.updateAndDismissAfter(dismiss = navigateBack)
@@ -112,6 +113,7 @@ private fun EditCustomUnitScreenPreview(
 @Composable
 private fun EditCustomUnitScreenContent(
     substanceName: String,
+    getSubstanceDisplayName: (String) -> String = { it },
     roaDose: RoaDose?,
     dismiss: () -> Unit,
     name: String,
@@ -137,7 +139,9 @@ private fun EditCustomUnitScreenContent(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("$substanceName unit") },
+                title = {
+                    Text(i18n("custom_unit_title", mapOf("substance" to getSubstanceDisplayName(substanceName))))
+                },
                 actions = {
                     var isShowingDeleteDialog by remember { mutableStateOf(false) }
                     IconButton(onClick = { isShowingDeleteDialog = true }) {


### PR DESCRIPTION
Display names now render through SubstanceRepository.getDisplayName (localizedName ?: name) at the render point only — the substanceName parameters and stored keys stay raw, so comparisons like the Cannabis THC disclaimer and route/data keys are unaffected:
- ChooseDoseScreen: dose title; Cannabis checks untouched
- ChooseTimeScreen: ingestion title + color card (new i18n key choose_time_color_title with {substance} placeholder)
- ChooseRouteDuringAddCustomUnitScreen: route title
- ChooseDoseCustomUnitScreen / FinishAddCustomUnitScreen / EditCustomUnitScreen: titles via getSubstanceDisplayName lambda, custom_unit_title key localizes the 'unit' suffix New keys x3 languages; VMs expose the repo (ChooseDoseViewModel val, ChooseTimeViewModel injects SubstanceRepository)