### PR TITLE
feat: localize interaction settings options; make substance interacti…

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -610,5 +610,19 @@
   "stats_report_period_days_30": "Last 30 days",
   "stats_report_period_weeks_26": "Last 6 months",
   "stats_report_period_months_12": "Last 12 months",
-  "stats_report_period_years_10": "Last 10 years"
+  "stats_report_period_years_10": "Last 10 years",
+  "settings_interaction_option_alcohol": "Alcohol",
+  "settings_interaction_option_caffeine": "Caffeine",
+  "settings_interaction_option_cannabis": "Cannabis",
+  "settings_interaction_option_grapefruit": "Grapefruit",
+  "settings_interaction_option_hormonal_birth_control": "Hormonal birth control",
+  "settings_interaction_option_nicotine": "Nicotine",
+  "settings_interaction_option_lithium": "Lithium",
+  "settings_interaction_option_maoi": "MAOI",
+  "settings_interaction_option_ssris": "SSRIs",
+  "settings_interaction_option_snris": "SNRIs",
+  "settings_interaction_option_5-hydroxytryptophan": "5-Hydroxytryptophan",
+  "settings_interaction_option_tricyclic_antidepressants": "Tricyclic antidepressants",
+  "settings_interaction_option_antibiotics": "Antibiotics",
+  "settings_interaction_option_antihistamine": "Antihistamine"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -610,5 +610,19 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 个月",
   "stats_report_period_months_12": "最近 12 个月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "settings_interaction_option_alcohol": "酒精",
+  "settings_interaction_option_caffeine": "咖啡因",
+  "settings_interaction_option_cannabis": "大麻",
+  "settings_interaction_option_grapefruit": "西柚",
+  "settings_interaction_option_hormonal_birth_control": "激素类避孕药",
+  "settings_interaction_option_nicotine": "尼古丁",
+  "settings_interaction_option_lithium": "锂盐",
+  "settings_interaction_option_maoi": "单胺氧化酶抑制剂",
+  "settings_interaction_option_ssris": "选择性血清素再摄取抑制剂",
+  "settings_interaction_option_snris": "血清素与去甲肾上腺素再摄取抑制剂",
+  "settings_interaction_option_5-hydroxytryptophan": "5-羟基色氨酸",
+  "settings_interaction_option_tricyclic_antidepressants": "三环类抗抑郁药",
+  "settings_interaction_option_antibiotics": "抗生素",
+  "settings_interaction_option_antihistamine": "抗组胺药"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -610,5 +610,19 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 個月",
   "stats_report_period_months_12": "最近 12 個月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "settings_interaction_option_alcohol": "酒精",
+  "settings_interaction_option_caffeine": "咖啡因",
+  "settings_interaction_option_cannabis": "大麻",
+  "settings_interaction_option_grapefruit": "西柚",
+  "settings_interaction_option_hormonal_birth_control": "激素類避孕藥",
+  "settings_interaction_option_nicotine": "尼古丁",
+  "settings_interaction_option_lithium": "鋰鹽",
+  "settings_interaction_option_maoi": "單胺氧化酶抑制劑",
+  "settings_interaction_option_ssris": "選擇性血清素再吸收抑制劑",
+  "settings_interaction_option_snris": "血清素與正腎上腺素再吸收抑制劑",
+  "settings_interaction_option_5-hydroxytryptophan": "5-羥基色氨酸",
+  "settings_interaction_option_tricyclic_antidepressants": "三環類抗憂鬱藥",
+  "settings_interaction_option_antibiotics": "抗生素",
+  "settings_interaction_option_antihistamine": "抗組織胺藥"
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/InteractionsView.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/InteractionsView.kt
@@ -18,6 +18,7 @@
 
 package com.isaakhanimann.journal.ui.tabs.search.substance
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -68,14 +69,21 @@ fun InteractionsView(
     interactions: Interactions,
     substanceURL: String,
     navigateToURL: (url: String) -> Unit,
-    displayNameForSubstance: (name: String) -> String
+    displayNameForSubstance: (name: String) -> String,
+    navigateToSubstance: (substanceName: String) -> Unit = {},
+    isSubstance: (name: String) -> Boolean = { false }
 ) {
     Column {
         if (interactions.dangerous.isNotEmpty()) {
             interactions.dangerous.forEach {
                 InteractionRowSubstanceScreen(
                     text = displayNameForSubstance(it),
-                    interactionType = InteractionType.DANGEROUS
+                    interactionType = InteractionType.DANGEROUS,
+                    onClick = if (isSubstance(it)) {
+                        { navigateToSubstance(it) }
+                    } else {
+                        null
+                    }
                 )
             }
         }
@@ -83,7 +91,12 @@ fun InteractionsView(
             interactions.unsafe.forEach {
                 InteractionRowSubstanceScreen(
                     text = displayNameForSubstance(it),
-                    interactionType = InteractionType.UNSAFE
+                    interactionType = InteractionType.UNSAFE,
+                    onClick = if (isSubstance(it)) {
+                        { navigateToSubstance(it) }
+                    } else {
+                        null
+                    }
                 )
             }
         }
@@ -91,7 +104,12 @@ fun InteractionsView(
             interactions.uncertain.forEach {
                 InteractionRowSubstanceScreen(
                     text = displayNameForSubstance(it),
-                    interactionType = InteractionType.UNCERTAIN
+                    interactionType = InteractionType.UNCERTAIN,
+                    onClick = if (isSubstance(it)) {
+                        { navigateToSubstance(it) }
+                    } else {
+                        null
+                    }
                 )
             }
         }
@@ -118,11 +136,13 @@ fun InteractionExplanationButton(substanceURL: String, navigateToURL: (url: Stri
 fun InteractionRowSubstanceScreen(
     text: String,
     interactionType: InteractionType,
-    verticalPaddingInside: Dp = 2.dp
+    verticalPaddingInside: Dp = 2.dp,
+    onClick: (() -> Unit)? = null
 ) {
     Surface(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable(enabled = onClick != null) { onClick?.invoke() },
         shape = RectangleShape,
         color = interactionType.color
     ) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
@@ -485,7 +485,9 @@ fun SubstanceScreen(
                             navigateToURL = navigateToURL,
                             displayNameForSubstance = { name ->
                                 interactionNameLookup[name] ?: name
-                            }
+                            },
+                            navigateToSubstance = navigateToSubstanceScreen,
+                            isSubstance = substanceRepo::isSubstance
                         )
                     }
                 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/CombinationSettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/CombinationSettingsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 
 @Composable
@@ -97,7 +98,11 @@ fun CombinationSettingsScreen(substanceInteractions: List<SubstanceInteraction>)
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(text = substanceInteraction.name)
+                            // The stored option name is the English identifier; display it
+                            // through the i18n layer (key: settings_interaction_option_<name>).
+                            val key = "settings_interaction_option_" +
+                                substanceInteraction.name.lowercase().replace(' ', '_')
+                            Text(text = i18nOrDefault(key, substanceInteraction.name))
                             Switch(
                                 checked = substanceInteraction.isOn,
                                 onCheckedChange = { substanceInteraction.toggle() }


### PR DESCRIPTION
…on rows tappable

- CombinationSettingsScreen: option names now render through i18n (settings_interaction_option_<name>, 14 keys x 3 languages) instead of hardcoded English identifiers
- InteractionsView: interaction rows navigate to the matching substance screen when the entry is a known substance (isSubstance check); category entries (SSRIs etc.) stay non-clickable; rows use the original name as the route key, display name unchanged