### PR TITLE
feat: quick custom unit entry on the dose screen

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -610,5 +610,16 @@
   "stats_report_period_days_30": "Last 30 days",
   "stats_report_period_weeks_26": "Last 6 months",
   "stats_report_period_months_12": "Last 12 months",
-  "stats_report_period_years_10": "Last 10 years"
+  "stats_report_period_years_10": "Last 10 years",
+  "quick_custom_unit": "Quick custom unit",
+  "quick_custom_unit_title": "Custom unit",
+  "quick_custom_unit_existing": "Existing units",
+  "quick_custom_unit_new": "New unit",
+  "quick_custom_unit_name": "Unit name",
+  "quick_custom_unit_dose": "Dose per unit",
+  "quick_custom_unit_unit": "Unit",
+  "quick_custom_unit_count": "{count} × {unit} ({dose} {originalUnit})",
+  "quick_custom_unit_count_label": "Count",
+  "quick_custom_unit_converted": "= {dose} {unit}",
+  "quick_custom_unit_clear": "Clear"
 }

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -610,5 +610,16 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 个月",
   "stats_report_period_months_12": "最近 12 个月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "quick_custom_unit": "快速自定义单位",
+  "quick_custom_unit_title": "自定义单位",
+  "quick_custom_unit_existing": "已有单位",
+  "quick_custom_unit_new": "新建单位",
+  "quick_custom_unit_name": "单位名称",
+  "quick_custom_unit_dose": "每单位剂量",
+  "quick_custom_unit_unit": "单位",
+  "quick_custom_unit_count": "{count} × {unit}（{dose} {originalUnit}）",
+  "quick_custom_unit_count_label": "数量",
+  "quick_custom_unit_converted": "= {dose} {unit}",
+  "quick_custom_unit_clear": "清除"
 }

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -610,5 +610,16 @@
   "stats_report_period_days_30": "最近 30 天",
   "stats_report_period_weeks_26": "最近 6 個月",
   "stats_report_period_months_12": "最近 12 個月",
-  "stats_report_period_years_10": "最近 10 年"
+  "stats_report_period_years_10": "最近 10 年",
+  "quick_custom_unit": "快速自訂單位",
+  "quick_custom_unit_title": "自訂單位",
+  "quick_custom_unit_existing": "已有單位",
+  "quick_custom_unit_new": "新建單位",
+  "quick_custom_unit_name": "單位名稱",
+  "quick_custom_unit_dose": "每單位劑量",
+  "quick_custom_unit_unit": "單位",
+  "quick_custom_unit_count": "{count} × {unit}（{dose} {originalUnit}）",
+  "quick_custom_unit_count_label": "數量",
+  "quick_custom_unit_converted": "= {dose} {unit}",
+  "quick_custom_unit_clear": "清除"
 }

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
@@ -310,7 +310,7 @@ interface ExperienceDao {
     suspend fun insert(rating: ShulginRating)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insert(customUnit: CustomUnit)
+    suspend fun insert(customUnit: CustomUnit): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(timedNote: TimedNote)

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.flow.flowOn
 @Singleton
 class ExperienceRepository @Inject constructor(private val experienceDao: ExperienceDao) {
     suspend fun insert(rating: ShulginRating) = experienceDao.insert(rating)
-    suspend fun insert(customUnit: CustomUnit) = experienceDao.insert(customUnit)
+    suspend fun insert(customUnit: CustomUnit): Long = experienceDao.insert(customUnit)
     suspend fun insert(timedNote: TimedNote) = experienceDao.insert(timedNote)
     suspend fun update(experience: Experience) = experienceDao.update(experience)
     suspend fun update(ingestion: Ingestion) = experienceDao.update(ingestion)

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/graphs/addIngestionGraph.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/graphs/addIngestionGraph.kt
@@ -229,7 +229,8 @@ fun NavGraphBuilder.addIngestionGraph(navController: NavController) {
                         units,
                         isEstimate,
                         dose,
-                        estimatedDoseStandardDeviation
+                        estimatedDoseStandardDeviation,
+                        customUnitId
                     ->
                     val args = backStackEntry.arguments!!
                     val substanceName = args.getString(SUBSTANCE_NAME_KEY)!!
@@ -242,7 +243,7 @@ fun NavGraphBuilder.addIngestionGraph(navController: NavController) {
                         dose = dose,
                         estimatedDoseStandardDeviation = estimatedDoseStandardDeviation,
                         substanceName = substanceName,
-                        customUnitId = null,
+                        customUnitId = customUnitId,
                         customSubstanceId = null
                     )
                 },

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -37,6 +38,7 @@ import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Newspaper
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,6 +48,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -67,6 +70,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.isaakhanimann.journal.data.room.experiences.entities.CustomUnit
 import com.isaakhanimann.journal.data.substances.AdministrationRoute
 import com.isaakhanimann.journal.data.substances.classes.roa.DoseClass
 import com.isaakhanimann.journal.data.substances.classes.roa.RoaDose
@@ -74,6 +78,7 @@ import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.dose.RoaDosePreviewProvider
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.dose.RoaDoseView
+import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.administrationRouteKey
 
@@ -83,7 +88,8 @@ fun ChooseDoseScreen(
         units: String?,
         isEstimate: Boolean,
         dose: Double?,
-        estimatedDoseStandardDeviation: Double?
+        estimatedDoseStandardDeviation: Double?,
+        customUnitId: Int?
     ) -> Unit,
     navigateToVolumetricDosingScreenOnJournalTab: () -> Unit,
     navigateToURL: (url: String) -> Unit,
@@ -107,11 +113,14 @@ fun ChooseDoseScreen(
             viewModel.isEstimate = it
         },
         navigateToNext = {
+            val customUnit = viewModel.customUnitsFlow.value
+                .firstOrNull { it.id == viewModel.selectedCustomUnitId }
             navigateToChooseTimeAndMaybeColor(
                 viewModel.units,
                 viewModel.isEstimate,
-                viewModel.dose,
-                viewModel.estimatedDoseStandardDeviation
+                viewModel.doseForNext(customUnit),
+                viewModel.estimatedDoseStandardDeviation,
+                viewModel.selectedCustomUnitId
             )
         },
         navigateToURL = navigateToURL,
@@ -119,6 +128,7 @@ fun ChooseDoseScreen(
             navigateToChooseTimeAndMaybeColor(
                 viewModel.units,
                 false,
+                null,
                 null,
                 null
             )
@@ -132,7 +142,18 @@ fun ChooseDoseScreen(
         convertedDoseAndUnitText = viewModel.rawDoseWithUnit,
         isShowingUnitsField = viewModel.roaDose?.units?.isBlank() ?: true,
         units = viewModel.units,
-        onChangeOfUnits = { viewModel.units = it }
+        onChangeOfUnits = { viewModel.units = it },
+        customUnits = viewModel.customUnitsFlow.collectAsState().value,
+        selectedCustomUnitId = viewModel.selectedCustomUnitId,
+        onSelectCustomUnit = viewModel::selectCustomUnit,
+        onCreateCustomUnit = viewModel::createCustomUnit,
+        onClearCustomUnit = viewModel::clearCustomUnit,
+        quickUnitName = viewModel.quickUnitName,
+        onQuickUnitNameChange = { viewModel.quickUnitName = it },
+        quickUnitDoseText = viewModel.quickUnitDoseText,
+        onQuickUnitDoseTextChange = { viewModel.quickUnitDoseText = it },
+        quickUnitUnitText = viewModel.quickUnitUnitText,
+        onQuickUnitUnitTextChange = { viewModel.quickUnitUnitText = it }
     )
 }
 
@@ -224,7 +245,18 @@ fun ChooseDoseScreen(
     convertedDoseAndUnitText: String?,
     isShowingUnitsField: Boolean,
     units: String,
-    onChangeOfUnits: (units: String) -> Unit
+    onChangeOfUnits: (units: String) -> Unit,
+    customUnits: List<CustomUnit> = emptyList(),
+    selectedCustomUnitId: Int? = null,
+    onSelectCustomUnit: (Int?) -> Unit = {},
+    onCreateCustomUnit: () -> Unit = {},
+    onClearCustomUnit: () -> Unit = {},
+    quickUnitName: String = "",
+    onQuickUnitNameChange: (String) -> Unit = {},
+    quickUnitDoseText: String = "",
+    onQuickUnitDoseTextChange: (String) -> Unit = {},
+    quickUnitUnitText: String = "",
+    onQuickUnitUnitTextChange: (String) -> Unit = {}
 ) {
     Scaffold(
         topBar = {
@@ -323,11 +355,22 @@ fun ChooseDoseScreen(
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
                     }
+                    val selectedCustomUnitForLabel =
+                        customUnits.firstOrNull { it.id == selectedCustomUnitId }
                     OutlinedTextField(
                         value = doseText,
                         onValueChange = onChangeDoseText,
                         textStyle = textStyle,
-                        label = { Text(i18n("dose_label"), style = textStyle) },
+                        label = {
+                            Text(
+                                if (selectedCustomUnitForLabel != null) {
+                                    i18n("quick_custom_unit_count_label")
+                                } else {
+                                    i18n("dose_label")
+                                },
+                                style = textStyle
+                            )
+                        },
                         isError = !isValidDose,
                         trailingIcon = {
                             Text(
@@ -405,6 +448,135 @@ fun ChooseDoseScreen(
                             singleLine = true,
                             modifier = Modifier.fillMaxWidth()
                         )
+                    }
+
+                    // --- Quick custom unit ---
+                    val selectedCustomUnit =
+                        customUnits.firstOrNull { it.id == selectedCustomUnitId }
+                    var isShowingQuickUnitDialog by remember { mutableStateOf(false) }
+                    if (selectedCustomUnit != null) {
+                        val quantity = doseText.toDoubleOrNull()
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = i18n(
+                                    "quick_custom_unit_count",
+                                    mapOf(
+                                        "unit" to selectedCustomUnit.name,
+                                        "dose" to selectedCustomUnit.dose.toReadableString(),
+                                        "originalUnit" to selectedCustomUnit.originalUnit
+                                    )
+                                ),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            TextButton(onClick = onClearCustomUnit) {
+                                Text(text = i18n("quick_custom_unit_clear"))
+                            }
+                        }
+                        if (quantity != null) {
+                            Text(
+                                text = i18n(
+                                    "quick_custom_unit_converted",
+                                    mapOf(
+                                        "dose" to (quantity * selectedCustomUnit.dose).toReadableString(),
+                                        "unit" to selectedCustomUnit.originalUnit
+                                    )
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    } else {
+                        TextButton(onClick = { isShowingQuickUnitDialog = true }) {
+                            Text(text = i18n("quick_custom_unit"))
+                        }
+                        if (isShowingQuickUnitDialog) {
+                            AlertDialog(
+                                onDismissRequest = { isShowingQuickUnitDialog = false },
+                                title = { Text(i18n("quick_custom_unit_title")) },
+                                text = {
+                                    Column(
+                                        modifier = Modifier.verticalScroll(rememberScrollState())
+                                    ) {
+                                        if (customUnits.isNotEmpty()) {
+                                            Text(
+                                                text = i18n("quick_custom_unit_existing"),
+                                                style = MaterialTheme.typography.titleSmall
+                                            )
+                                            customUnits.forEach { unit ->
+                                                Row(
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .clickable {
+                                                            onSelectCustomUnit(unit.id)
+                                                            isShowingQuickUnitDialog = false
+                                                        }
+                                                ) {
+                                                    RadioButton(
+                                                        selected = unit.id == selectedCustomUnitId,
+                                                        onClick = null
+                                                    )
+                                                    Text(
+                                                        text = "${unit.name} · ${unit.dose.toReadableString()} ${unit.originalUnit}"
+                                                    )
+                                                }
+                                            }
+                                            Spacer(modifier = Modifier.height(8.dp))
+                                        }
+                                        Text(
+                                            text = i18n("quick_custom_unit_new"),
+                                            style = MaterialTheme.typography.titleSmall
+                                        )
+                                        OutlinedTextField(
+                                            value = quickUnitName,
+                                            onValueChange = onQuickUnitNameChange,
+                                            label = { Text(i18n("quick_custom_unit_name")) },
+                                            singleLine = true,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                        OutlinedTextField(
+                                            value = quickUnitDoseText,
+                                            onValueChange = onQuickUnitDoseTextChange,
+                                            label = { Text(i18n("quick_custom_unit_dose")) },
+                                            keyboardOptions = KeyboardOptions(
+                                                keyboardType = KeyboardType.Number
+                                            ),
+                                            singleLine = true,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                        OutlinedTextField(
+                                            value = quickUnitUnitText,
+                                            onValueChange = onQuickUnitUnitTextChange,
+                                            label = { Text(i18n("quick_custom_unit_unit")) },
+                                            singleLine = true,
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                    }
+                                },
+                                confirmButton = {
+                                    TextButton(
+                                        enabled = quickUnitName.isNotBlank() &&
+                                            quickUnitDoseText.toDoubleOrNull() != null &&
+                                            quickUnitUnitText.isNotBlank(),
+                                        onClick = {
+                                            onCreateCustomUnit()
+                                            isShowingQuickUnitDialog = false
+                                        }
+                                    ) {
+                                        Text(i18n("common_done"))
+                                    }
+                                },
+                                dismissButton = {
+                                    TextButton(onClick = { isShowingQuickUnitDialog = false }) {
+                                        Text(i18n("common_cancel"))
+                                    }
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/dose/ChooseDoseViewModel.kt
@@ -23,6 +23,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import com.isaakhanimann.journal.data.room.experiences.entities.CustomUnit
 import com.isaakhanimann.journal.data.substances.AdministrationRoute
 import com.isaakhanimann.journal.data.substances.classes.Substance
 import com.isaakhanimann.journal.data.substances.classes.roa.DoseClass
@@ -33,10 +36,14 @@ import com.isaakhanimann.journal.ui.main.navigation.routers.SUBSTANCE_NAME_KEY
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ChooseDoseViewModel @Inject constructor(
-    repository: SubstanceRepository,
+    val repository: SubstanceRepository,
+    private val experienceRepo: ExperienceRepository,
     state: SavedStateHandle
 ) : ViewModel() {
     val substance: Substance
@@ -47,6 +54,59 @@ class ChooseDoseViewModel @Inject constructor(
     var estimatedDoseStandardDeviationText by mutableStateOf("")
     var purityText by mutableStateOf("100")
     var units by mutableStateOf("")
+
+    // --- Quick custom unit support ---
+    private val substanceName = state.get<String>(SUBSTANCE_NAME_KEY)!!
+
+    val customUnitsFlow = experienceRepo.getUnArchivedCustomUnitsFlow(substanceName).stateIn(
+        initialValue = emptyList(),
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
+
+    var selectedCustomUnitId by mutableStateOf<Int?>(null)
+        private set
+
+    // Dialog inputs, prefilled from the current dose fields.
+    var quickUnitName by mutableStateOf("")
+    var quickUnitDoseText by mutableStateOf("")
+    var quickUnitUnitText by mutableStateOf("")
+
+    fun selectCustomUnit(customUnitId: Int?) {
+        selectedCustomUnitId = customUnitId
+    }
+
+    fun createCustomUnit() {
+        val unitDose = quickUnitDoseText.toDoubleOrNull() ?: return
+        val name = quickUnitName.trim()
+        if (name.isEmpty()) return
+        val unit = quickUnitUnitText.trim()
+        if (unit.isEmpty()) return
+        val newCustomUnit = CustomUnit(
+            substanceName = substanceName,
+            name = name,
+            administrationRoute = administrationRoute,
+            dose = unitDose,
+            estimatedDoseStandardDeviation = null,
+            isEstimate = false,
+            isArchived = false,
+            unit = unit,
+            originalUnit = units.ifBlank { roaDose?.units ?: "mg" },
+            note = ""
+        )
+        viewModelScope.launch {
+            val id = experienceRepo.insert(customUnit = newCustomUnit)
+            selectedCustomUnitId = id.toInt()
+            quickUnitName = ""
+            quickUnitDoseText = ""
+            quickUnitUnitText = ""
+        }
+    }
+
+    fun clearCustomUnit() {
+        selectedCustomUnitId = null
+    }
+
     private val purity: Double?
         get() {
             val p = purityText.toDoubleOrNull()
@@ -68,6 +128,15 @@ class ChooseDoseViewModel @Inject constructor(
                 }
             }
         }
+
+    /** The dose value to persist: in custom-unit mode the input is a count. */
+    fun doseForNext(customUnit: CustomUnit?): Double? =
+        if (customUnit != null) {
+            doseText.toDoubleOrNull()?.times(customUnit.dose)
+        } else {
+            dose
+        }
+
     val dose: Double? get() = doseText.toDoubleOrNull()
     val estimatedDoseStandardDeviation: Double? get() = estimatedDoseStandardDeviationText.toDoubleOrNull()
     val isValidDose: Boolean get() = dose != null


### PR DESCRIPTION
ChooseDoseScreen (add-ingestion dose step) gets a 'Quick custom unit' entry that opens a dialog showing matching custom units for the substance
+ route and a create form (name, dose per unit, unit), prefilled from the current dose fields. Selecting or creating a unit switches the dose input to count mode: the entered count is multiplied by the unit dose on save (customUnitId flows through to the ingestion), with a live conversion preview and a clear action. CustomUnit insert now returns the row id; DAO/repo updated.