### PR TITLE
feat: type-to-confirm delete-everything dialog

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -670,5 +670,6 @@
   "time_between": "Time between",
   "finish_substance_color": "{substance} color",
   "suggestion_enter_dose": "Enter {unit}",
-  "sd_means": "means:"
-}
+  "sd_means": "means:",
+  "common_confirm": "Confirm",
+  "settings_delete_type_confirm": "Type \"Delete\" to confirm"}

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -670,5 +670,6 @@
   "time_between": "时间间隔",
   "finish_substance_color": "{substance} 的颜色",
   "suggestion_enter_dose": "输入 {unit}",
-  "sd_means": "表示："
-}
+  "sd_means": "表示：",
+  "common_confirm": "确认",
+  "settings_delete_type_confirm": "输入 \"Delete\" 以确认"}

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -670,5 +670,6 @@
   "time_between": "時間間隔",
   "finish_substance_color": "{substance} 的顏色",
   "suggestion_enter_dose": "輸入 {unit}",
-  "sd_means": "表示："
-}
+  "sd_means": "表示：",
+  "common_confirm": "確認",
+  "settings_delete_type_confirm": "輸入 \"Delete\" 以確認"}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material.icons.outlined.VolunteerActivism
 import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.*
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -76,7 +77,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -104,8 +104,6 @@ import kotlinx.coroutines.launch
 
 import androidx.compose.foundation.layout.height
 
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
 
 
 
@@ -596,8 +594,7 @@ fun SettingsScreen(
                 }
                 HorizontalDivider()
                 var isShowingDeleteDialog by remember { mutableStateOf(false) }
-                
-                var deleteSliderValue by remember { mutableFloatStateOf(0f) }
+                var deleteConfirmText by remember { mutableStateOf("") }
                 
                 SettingsButton(
                     imageVector = Icons.Outlined.DeleteForever,
@@ -609,9 +606,9 @@ fun SettingsScreen(
                 val deletedSnackbarMessage = i18n("settings_deleted_snackbar")
                 AnimatedVisibility(visible = isShowingDeleteDialog) {
                     AlertDialog(
-                        onDismissRequest = { 
-                            isShowingDeleteDialog = false 
-                            deleteSliderValue = 0f         
+                        onDismissRequest = {
+                            isShowingDeleteDialog = false
+                            deleteConfirmText = ""
                         },
                         title = {
                             Text(text = i18n("settings_delete_title"))
@@ -622,43 +619,38 @@ fun SettingsScreen(
 
                                 Spacer(modifier = Modifier.height(16.dp))
 
-                                Icon(
-                                    imageVector = if (deleteSliderValue >= 0.98f) Icons.Outlined.DeleteForever else Icons.Outlined.WarningAmber,
-                                    contentDescription = i18n("settings_delete_title"),
-                                    modifier = Modifier
-                                        .size(32.dp)
-                                        .clip(CircleShape),
-                                    tint = if (deleteSliderValue >= 0.98f) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.errorContainer,
-                                )
-
-                                Slider(
-                                    value = deleteSliderValue,
-                                    onValueChange = { deleteSliderValue = it },
-                                    onValueChangeFinished = {
-                                        if (deleteSliderValue >= 0.98f) {
-                                            isShowingDeleteDialog = false
-                                            deleteEverything()
-                                            scope.launch {
-                                                snackbarHostState.showSnackbar(
-                                                    message = deletedSnackbarMessage,
-                                                    duration = SnackbarDuration.Short
-                                                )
-                                            }
-                                            deleteSliderValue = 0f
-                                        } else {
-                                            deleteSliderValue = 0f
-                                        }
-                                    },
-                                    valueRange = 0f..1f,
-                                    colors = SliderDefaults.colors(
-                                        thumbColor = MaterialTheme.colorScheme.error,
-                                        activeTrackColor = MaterialTheme.colorScheme.error,
-                                        inactiveTrackColor = MaterialTheme.colorScheme.errorContainer
-                                    )
+                                OutlinedTextField(
+                                    value = deleteConfirmText,
+                                    onValueChange = { deleteConfirmText = it },
+                                    label = { Text(i18n("settings_delete_type_confirm")) },
+                                    singleLine = true,
+                                    isError = deleteConfirmText.isNotBlank() && deleteConfirmText.trim() != "Delete",
+                                    modifier = Modifier.fillMaxWidth()
                                 )
                             }
                         },
-                        confirmButton = {}
+                        confirmButton = {
+                            Button(
+                                onClick = {
+                                    isShowingDeleteDialog = false
+                                    deleteConfirmText = ""
+                                    deleteEverything()
+                                    scope.launch {
+                                        snackbarHostState.showSnackbar(
+                                            message = deletedSnackbarMessage,
+                                            duration = SnackbarDuration.Short
+                                        )
+                                    }
+                                },
+                                enabled = deleteConfirmText.trim() == "Delete",
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.error,
+                                    disabledContainerColor = MaterialTheme.colorScheme.errorContainer
+                                )
+                            ) {
+                                Text(i18n("common_confirm"))
+                            }
+                        }
                     )
                 }
             }


### PR DESCRIPTION
Replace the slide-to-confirm slider in the delete-everything alert with a text field requiring the exact word "Delete" before the Confirm button enables (error-colored when enabled, disabled state otherwise).