### PR TITLE
fix: crash opening TimelineScreen when consumer filter yields no data

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -672,4 +672,6 @@
   "suggestion_enter_dose": "Enter {unit}",
   "sd_means": "means:",
   "common_confirm": "Confirm",
-  "settings_delete_type_confirm": "Type \"Delete\" to confirm"}
+  "settings_delete_type_confirm": "Type \"Delete\" to confirm",
+  "timeline_screen_no_data": "No timeline data for this consumer"
+}

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -672,4 +672,6 @@
   "suggestion_enter_dose": "输入 {unit}",
   "sd_means": "表示：",
   "common_confirm": "确认",
-  "settings_delete_type_confirm": "输入 \"Delete\" 以确认"}
+  "settings_delete_type_confirm": "输入 \"Delete\" 以确认",
+  "timeline_screen_no_data": "该记录人暂无时间线数据"
+}

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -672,4 +672,6 @@
   "suggestion_enter_dose": "輸入 {unit}",
   "sd_means": "表示：",
   "common_confirm": "確認",
-  "settings_delete_type_confirm": "輸入 \"Delete\" 以確認"}
+  "settings_delete_type_confirm": "輸入 \"Delete\" 以確認",
+  "timeline_screen_no_data": "該記錄人暫無時間線資料"
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/AllTimelinesModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/AllTimelinesModel.kt
@@ -50,8 +50,7 @@ class AllTimelinesModel(
         val ingestionTimes = dataForLines.map { it.startTime }
         val noteTimes = timedNotes.map { it.time }
         val allStartTimeCandidates = ratingTimes + ingestionTimes + noteTimes
-        startTime =
-            allStartTimeCandidates.reduce { acc, date -> if (acc.isBefore(date)) acc else date }
+        startTime = allStartTimeCandidates.minOrNull() ?: Instant.EPOCH
         val roaGroups = dataForLines.groupBy { it.substanceName }
             .flatMap { substanceGroup ->
                 val linesPerSubstance = substanceGroup.value

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/screen/TimelineScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/screen/TimelineScreen.kt
@@ -191,6 +191,21 @@ fun TimelineScreen(timelineScreenModel: TimelineScreenModel) {
             var canvasWidth by remember { mutableFloatStateOf(screenWidth) }
             val isOrientationPortrait =
                 LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
+            if (timelineScreenModel.ingestionElements.isEmpty() &&
+                timelineScreenModel.ratings.isEmpty() &&
+                timelineScreenModel.timedNotes.isEmpty()
+            ) {
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = i18n("timeline_screen_no_data"),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
             Box(
                 modifier = Modifier
                     .weight(1f)
@@ -221,6 +236,7 @@ fun TimelineScreen(timelineScreenModel: TimelineScreenModel) {
                         .width(canvasWidth.dp)
                         .padding(horizontal = horizontalPadding)
                 )
+            }
             }
             Slider(
                 value = canvasWidth,


### PR DESCRIPTION
AllTimelinesModel computed startTime with reduce() over the combined rating/ingestion/note times; after the TimelineScreenViewModel consumerName filter (owner branch matches consumerName == null) the list can be empty, and reduce() throws UnsupportedOperationException, crashing on entry.

- AllTimelinesModel: startTime = minOrNull() ?: Instant.EPOCH (empty-safe)
- TimelineScreen: show a localized 'no timeline data' empty state instead of rendering an empty timeline when nothing matches the consumer