### PR TITLE
fix: translate substance names in the substance-colors screen

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsScreen.kt
@@ -56,7 +56,8 @@ fun SubstanceColorsScreen(
         substanceCompanions = viewModel.substanceCompanionsFlow.collectAsState().value,
         updateColor = viewModel::updateColor,
         alreadyUsedColors = viewModel.alreadyUsedColorsFlow.collectAsState().value,
-        otherColors = viewModel.otherColorsFlow.collectAsState().value
+        otherColors = viewModel.otherColorsFlow.collectAsState().value,
+        getSubstanceDisplayName = viewModel.substanceRepository::getDisplayName
     )
 }
 
@@ -77,7 +78,8 @@ fun SubstanceColorsScreenPreview() {
         ),
         updateColor = { _, _ -> },
         alreadyUsedColors = alreadyUsedColors,
-        otherColors = otherColors
+        otherColors = otherColors,
+        getSubstanceDisplayName = { it }
 
     )
 }
@@ -88,7 +90,8 @@ fun SubstanceColorsScreenContent(
     substanceCompanions: List<SubstanceCompanion>,
     updateColor: (color: AdaptiveColor, substanceName: String) -> Unit,
     alreadyUsedColors: List<AdaptiveColor>,
-    otherColors: List<AdaptiveColor>
+    otherColors: List<AdaptiveColor>,
+    getSubstanceDisplayName: (String) -> String
 ) {
     Scaffold(
         topBar = {
@@ -110,7 +113,7 @@ fun SubstanceColorsScreenContent(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = substanceCompanion.substanceName,
+                        text = getSubstanceDisplayName(substanceCompanion.substanceName),
                         style = MaterialTheme.typography.titleMedium
                     )
                     ColorPicker(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/colors/SubstanceColorsViewModel.kt
@@ -21,6 +21,7 @@ package com.isaakhanimann.journal.ui.tabs.settings.colors
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepository
 import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
 import com.isaakhanimann.journal.data.room.experiences.entities.SubstanceCompanion
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,7 +35,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SubstanceColorsViewModel @Inject constructor(
-    private val experienceRepository: ExperienceRepository
+    private val experienceRepository: ExperienceRepository,
+    val substanceRepository: SubstanceRepository
 ) : ViewModel() {
 
     private val _substanceCompanionsFlow = MutableStateFlow<List<SubstanceCompanion>>(emptyList())


### PR DESCRIPTION
SubstanceColorsScreen listed raw registration keys; names now go through getSubstanceDisplayName (SubstanceRepository exposed on the VM), so custom and localized substance names render translated.