### PR TITLE
feat: add setting to split experiences at midnight (#114)

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -651,7 +651,7 @@
   "finish_time_end": "End:",
   "settings_hide_timeline": "Hide timeline",
   "settings_midnight_cutoff": "Split experiences at midnight",
-  "settings_midnight_cutoff_description": "When enabled, an ingestion after midnight starts a new experience instead of joining the previous day's. Useful if you treat each calendar day as its own experience.",
+  "settings_midnight_cutoff_description": "When enabled, an ingestion after midnight starts a new experience instead of joining the previous day's. Midnight is based on your local timezone. Useful if you treat each calendar day as its own experience.",
   "settings_independent_substance_heights": "Independent substance heights",
   "settings_independent_substance_heights_description": "Enable this setting if you want the timeline of different substances and routes of administration (roas) to be independent. Then ingestions of different substances and roas will always take the full height of the timeline.\n\nIf this setting is disabled then timelines of different substances have a height relative to each other. In that case the average of the common dose is used as the point to compare it to.\nE.g. if the oral average common dose of MDMA is 100mg and the average common dose of insufflated MDMA is 50mg then the timeline for 100mg of oral MDMA is the same height as for 50mg of insufflated MDMA.\nThis is also applied across substances. E.g. if the common dose of oral 2C-B is 20mg then the timeline of 40mg oral 2C-B will be twice as high as 100mg of oral MDMA.",
   "common_show_more_info": "Show more info",

--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -650,6 +650,8 @@
   "finish_time_start": "Start:",
   "finish_time_end": "End:",
   "settings_hide_timeline": "Hide timeline",
+  "settings_midnight_cutoff": "Split experiences at midnight",
+  "settings_midnight_cutoff_description": "When enabled, an ingestion after midnight starts a new experience instead of joining the previous day's. Useful if you treat each calendar day as its own experience.",
   "settings_independent_substance_heights": "Independent substance heights",
   "settings_independent_substance_heights_description": "Enable this setting if you want the timeline of different substances and routes of administration (roas) to be independent. Then ingestions of different substances and roas will always take the full height of the timeline.\n\nIf this setting is disabled then timelines of different substances have a height relative to each other. In that case the average of the common dose is used as the point to compare it to.\nE.g. if the oral average common dose of MDMA is 100mg and the average common dose of insufflated MDMA is 50mg then the timeline for 100mg of oral MDMA is the same height as for 50mg of insufflated MDMA.\nThis is also applied across substances. E.g. if the common dose of oral 2C-B is 20mg then the timeline of 40mg oral 2C-B will be twice as high as 100mg of oral MDMA.",
   "common_show_more_info": "Show more info",

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -651,7 +651,7 @@
   "finish_time_end": "结束：",
   "settings_hide_timeline": "隐藏时间线",
   "settings_midnight_cutoff": "午夜分割体验",
-  "settings_midnight_cutoff_description": "启用后，午夜之后的摄入会新建体验，而不会并入前一天。适合把每个自然日视为一次独立体验的使用方式。",
+  "settings_midnight_cutoff_description": "启用后，午夜之后的摄入会新建体验，而不会并入前一天。午夜按本地时区计算。适合把每个自然日视为一次独立体验的使用方式。",
   "settings_independent_substance_heights": "物质时间线高度独立",
   "settings_independent_substance_heights_description": "启用此设置后，不同物质和给药途径（roa）的时间线将彼此独立。不同物质和途径的摄入将始终占满时间线的全部高度。\n\n禁用时，不同物质的时间线高度彼此相对。此时以常见剂量平均值为比较基准。\n例如：口服 MDMA 的常见剂量平均值为 100mg，鼻吸 MDMA 为 50mg，则 100mg 口服 MDMA 的时间线高度与 50mg 鼻吸 MDMA 相同。\n该规则同样跨物质生效。例如口服 2C-B 的常见剂量为 20mg，则 40mg 口服 2C-B 的时间线是 100mg 口服 MDMA 的两倍高。",
   "common_show_more_info": "显示更多信息",

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -650,6 +650,8 @@
   "finish_time_start": "开始：",
   "finish_time_end": "结束：",
   "settings_hide_timeline": "隐藏时间线",
+  "settings_midnight_cutoff": "午夜分割体验",
+  "settings_midnight_cutoff_description": "启用后，午夜之后的摄入会新建体验，而不会并入前一天。适合把每个自然日视为一次独立体验的使用方式。",
   "settings_independent_substance_heights": "物质时间线高度独立",
   "settings_independent_substance_heights_description": "启用此设置后，不同物质和给药途径（roa）的时间线将彼此独立。不同物质和途径的摄入将始终占满时间线的全部高度。\n\n禁用时，不同物质的时间线高度彼此相对。此时以常见剂量平均值为比较基准。\n例如：口服 MDMA 的常见剂量平均值为 100mg，鼻吸 MDMA 为 50mg，则 100mg 口服 MDMA 的时间线高度与 50mg 鼻吸 MDMA 相同。\n该规则同样跨物质生效。例如口服 2C-B 的常见剂量为 20mg，则 40mg 口服 2C-B 的时间线是 100mg 口服 MDMA 的两倍高。",
   "common_show_more_info": "显示更多信息",

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -651,7 +651,7 @@
   "finish_time_end": "結束：",
   "settings_hide_timeline": "隱藏時間線",
   "settings_midnight_cutoff": "午夜分割體驗",
-  "settings_midnight_cutoff_description": "啟用後，午夜之後的攝入會新建體驗，而不會併入前一天。適合把每個自然日視為一次獨立體驗的使用方式。",
+  "settings_midnight_cutoff_description": "啟用後，午夜之後的攝入會新建體驗，而不會併入前一天。午夜依本地時區計算。適合把每個自然日視為一次獨立體驗的使用方式。",
   "settings_independent_substance_heights": "物質時間線高度獨立",
   "settings_independent_substance_heights_description": "啟用此設定後，不同物質和給藥途徑（roa）的時間線將彼此獨立。不同物質和途徑的攝入將始終佔滿時間線的全部高度。\n\n停用時，不同物質的時間線高度彼此相對。此時以常見劑量平均值為比較基準。\n例如：口服 MDMA 的常見劑量平均值為 100mg，鼻吸 MDMA 為 50mg，則 100mg 口服 MDMA 的時間線高度與 50mg 鼻吸 MDMA 相同。\n該規則同樣跨物質生效。例如口服 2C-B 的常見劑量為 20mg，則 40mg 口服 2C-B 的時間線是 100mg 口服 MDMA 的兩倍高。",
   "common_show_more_info": "顯示更多資訊",

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -650,6 +650,8 @@
   "finish_time_start": "開始：",
   "finish_time_end": "結束：",
   "settings_hide_timeline": "隱藏時間線",
+  "settings_midnight_cutoff": "午夜分割體驗",
+  "settings_midnight_cutoff_description": "啟用後，午夜之後的攝入會新建體驗，而不會併入前一天。適合把每個自然日視為一次獨立體驗的使用方式。",
   "settings_independent_substance_heights": "物質時間線高度獨立",
   "settings_independent_substance_heights_description": "啟用此設定後，不同物質和給藥途徑（roa）的時間線將彼此獨立。不同物質和途徑的攝入將始終佔滿時間線的全部高度。\n\n停用時，不同物質的時間線高度彼此相對。此時以常見劑量平均值為比較基準。\n例如：口服 MDMA 的常見劑量平均值為 100mg，鼻吸 MDMA 為 50mg，則 100mg 口服 MDMA 的時間線高度與 50mg 鼻吸 MDMA 相同。\n該規則同樣跨物質生效。例如口服 2C-B 的常見劑量為 20mg，則 40mg 口服 2C-B 的時間線是 100mg 口服 MDMA 的兩倍高。",
   "common_show_more_info": "顯示更多資訊",

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/FinishIngestionScreenViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/FinishIngestionScreenViewModel.kt
@@ -261,18 +261,13 @@ class FinishIngestionScreenViewModel @Inject constructor(
                 toInstant = toInstant
             )
         experiencesInRangeFlow.emit(experiencesInRange)
-        val closestExperience = experiencesInRange.firstOrNull { experience ->
-            val sortedIngestions = experience.ingestions.sortedBy { it.time }
-            val firstIngestionTime =
-                sortedIngestions.firstOrNull()?.time ?: return@firstOrNull false
-            val upperBoundBasedOnFirstIngestion = firstIngestionTime.plus(15, ChronoUnit.HOURS)
-            val lastIngestionTime = sortedIngestions.lastOrNull()?.time ?: return@firstOrNull false
-            val upperBoundBasedOnLastIngestion = lastIngestionTime.plus(3, ChronoUnit.HOURS)
-            val finalUpperBound =
-                maxOf(upperBoundBasedOnFirstIngestion, upperBoundBasedOnLastIngestion)
-            val lowerBound = firstIngestionTime.minus(3, ChronoUnit.HOURS)
-            return@firstOrNull selectedInstant in lowerBound..finalUpperBound
-        }
+        val enforceDayBoundary = userPreferences.isMidnightCutoffEnabledFlow.first()
+        val closestExperience = findClosestExperience(
+            experiences = experiencesInRange,
+            selectedInstant = selectedInstant,
+            zone = ZoneId.systemDefault(),
+            enforceDayBoundary = enforceDayBoundary
+        )
         selectedExperienceFlow.emit(closestExperience)
     }
 
@@ -355,5 +350,42 @@ class FinishIngestionScreenViewModel @Inject constructor(
             },
             customUnitId = customUnitId
         )
+    }
+}
+
+/**
+ * Picks the experience a new ingestion at [selectedInstant] should join, or null if it should
+ * start a new one.
+ *
+ * An experience matches when [selectedInstant] lies within its session window
+ * (first ingestion - 3h .. max(first ingestion + 15h, last ingestion + 3h)). When
+ * [enforceDayBoundary] is enabled, the instant must additionally fall on one of the calendar
+ * days the experience's own ingestions span, so an ingestion shortly after midnight starts a
+ * new experience instead of joining the previous day's.
+ */
+internal fun findClosestExperience(
+    experiences: List<ExperienceWithIngestions>,
+    selectedInstant: Instant,
+    zone: ZoneId,
+    enforceDayBoundary: Boolean
+): ExperienceWithIngestions? {
+    return experiences.firstOrNull { experience ->
+        val sortedIngestions = experience.ingestions.sortedBy { it.time }
+        val firstIngestionTime = sortedIngestions.firstOrNull()?.time ?: return@firstOrNull false
+        val upperBoundBasedOnFirstIngestion = firstIngestionTime.plus(15, ChronoUnit.HOURS)
+        val lastIngestionTime = sortedIngestions.lastOrNull()?.time ?: return@firstOrNull false
+        val upperBoundBasedOnLastIngestion = lastIngestionTime.plus(3, ChronoUnit.HOURS)
+        val finalUpperBound =
+            maxOf(upperBoundBasedOnFirstIngestion, upperBoundBasedOnLastIngestion)
+        val lowerBound = firstIngestionTime.minus(3, ChronoUnit.HOURS)
+        val isWithinSessionWindow = selectedInstant in lowerBound..finalUpperBound
+        if (!enforceDayBoundary) {
+            return@firstOrNull isWithinSessionWindow
+        }
+        val selectedDay = selectedInstant.atZone(zone).toLocalDate()
+        val firstIngestedDay = firstIngestionTime.atZone(zone).toLocalDate()
+        val lastIngestedDay = lastIngestionTime.atZone(zone).toLocalDate()
+        val isWithinIngestedDays = selectedDay in firstIngestedDay..lastIngestedDay
+        isWithinSessionWindow && isWithinIngestedDays
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/FinishIngestionScreenViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/FinishIngestionScreenViewModel.kt
@@ -376,7 +376,8 @@ class FinishIngestionScreenViewModel @Inject constructor(
  * [enforceDayBoundary] is enabled, the instant must additionally fall on one of the calendar
  * days the experience's own ingestions span, so an ingestion shortly after midnight starts a
  * new experience instead of joining the previous day's: a session only continues into the next
- * calendar day if it demonstrably crossed midnight.
+ * calendar day if it demonstrably crossed midnight. The day span is treated as a contiguous
+ * range: an experience with ingestions on non-adjacent days also matches a selected day in between.
  */
 internal fun findClosestExperience(
     experiences: List<ExperienceWithIngestions>,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -153,6 +153,8 @@ fun SettingsScreen(
         saveIsTimelineHidden = viewModel::saveIsTimelineHidden,
         areSubstanceHeightsIndependent = viewModel.areSubstanceHeightsIndependentFlow.collectAsState().value,
         saveAreSubstanceHeightsIndependent = viewModel::saveAreSubstanceHeightsIndependent,
+        isMidnightCutoffEnabled = viewModel.isMidnightCutoffEnabledFlow.collectAsState().value,
+        saveMidnightCutoffEnabled = viewModel::saveMidnightCutoffEnabled,
     )
 }
 
@@ -189,6 +191,8 @@ fun SettingsScreen(
     saveIsTimelineHidden: (Boolean) -> Unit,
     areSubstanceHeightsIndependent: Boolean,
     saveAreSubstanceHeightsIndependent: (Boolean) -> Unit,
+    isMidnightCutoffEnabled: Boolean,
+    saveMidnightCutoffEnabled: (Boolean) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -351,6 +355,27 @@ fun SettingsScreen(
                     Switch(
                         checked = areSubstanceHeightsIndependent,
                         onCheckedChange = saveAreSubstanceHeightsIndependent
+                    )
+                }
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = horizontalPadding, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(text = i18n("settings_midnight_cutoff"))
+                        Text(
+                            text = i18n("settings_midnight_cutoff_description"),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = isMidnightCutoffEnabled,
+                        onCheckedChange = saveMidnightCutoffEnabled
                     )
                 }
             }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
@@ -113,7 +113,7 @@ class SettingsViewModel @Inject constructor(
     )
 
     val isMidnightCutoffEnabledFlow = userPreferences.isMidnightCutoffEnabledFlow.stateIn(
-        initialValue = true,
+        initialValue = false,
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000)
     )

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
@@ -112,6 +112,18 @@ class SettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000)
     )
 
+    val isMidnightCutoffEnabledFlow = userPreferences.isMidnightCutoffEnabledFlow.stateIn(
+        initialValue = false,
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
+
+    fun saveMidnightCutoffEnabled(value: Boolean) {
+        viewModelScope.launch {
+            userPreferences.saveMidnightCutoffEnabled(value)
+        }
+    }
+
     val selectedLanguageFlow = userPreferences.selectedLanguageFlow.stateIn(
         initialValue = null,
         scope = viewModelScope,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -167,7 +167,7 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
 
     val isMidnightCutoffEnabledFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
-            preferences[PreferencesKeys.KEY_MIDNIGHT_CUTOFF_ENABLED] ?: true
+            preferences[PreferencesKeys.KEY_MIDNIGHT_CUTOFF_ENABLED] ?: false
         }
 
     suspend fun saveMidnightCutoffEnabled(value: Boolean) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -52,6 +52,7 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         val KEY_EFFECT_NOTIFICATION_ENABLED = booleanPreferencesKey("key_effect_notification_enabled")
         val KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT = booleanPreferencesKey("KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT")
         val KEY_IS_TIMELINE_HIDDEN = booleanPreferencesKey("KEY_IS_TIMELINE_HIDDEN")
+        val KEY_MIDNIGHT_CUTOFF_ENABLED = booleanPreferencesKey("key_midnight_cutoff_enabled")
     }
 
     suspend fun saveTimeDisplayOption(value: SavedTimeDisplayOption) {
@@ -161,6 +162,17 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
     suspend fun saveIsTimelineHidden(value: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.KEY_IS_TIMELINE_HIDDEN] = value
+        }
+    }
+
+    val isMidnightCutoffEnabledFlow: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.KEY_MIDNIGHT_CUTOFF_ENABLED] ?: false
+        }
+
+    suspend fun saveMidnightCutoffEnabled(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.KEY_MIDNIGHT_CUTOFF_ENABLED] = value
         }
     }
 

--- a/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
+++ b/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2022-2026. Isaak Hanimann.
+ * This file is part of PsychonautWiki Journal.
+ *
+ * PsychonautWiki Journal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * PsychonautWiki Journal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ */
+
+package com.isaakhanimann.journal.ui.tabs.journal.addingestion.time
+
+import com.isaakhanimann.journal.data.room.experiences.entities.Experience
+import com.isaakhanimann.journal.data.room.experiences.entities.Ingestion
+import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestions
+import com.isaakhanimann.journal.data.substances.AdministrationRoute
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TestFindClosestExperience {
+
+    private val zone: ZoneId = ZoneId.of("UTC")
+
+    private fun instantOf(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0): Instant =
+        LocalDateTime.of(year, month, day, hour, minute).atZone(zone).toInstant()
+
+    private fun experience(id: Int, ingestionTimes: List<Instant>): ExperienceWithIngestions {
+        val experience = Experience(
+            id = id,
+            title = "Experience $id",
+            text = "",
+            creationDate = ingestionTimes.first(),
+            sortDate = ingestionTimes.first(),
+            location = null
+        )
+        val ingestions = ingestionTimes.map { time ->
+            Ingestion(
+                substanceName = "LSD",
+                time = time,
+                creationDate = null,
+                administrationRoute = AdministrationRoute.ORAL,
+                dose = null,
+                isDoseAnEstimate = false,
+                estimatedDoseStandardDeviation = null,
+                units = null,
+                experienceId = id,
+                notes = null,
+                stomachFullness = null,
+                consumerName = null,
+                customUnitId = null
+            )
+        }
+        return ExperienceWithIngestions(experience = experience, ingestions = ingestions)
+    }
+
+    private val daytimeSession = experience(
+        id = 1,
+        ingestionTimes = listOf(
+            instantOf(2026, 8, 14, 12),
+            instantOf(2026, 8, 14, 16),
+            instantOf(2026, 8, 14, 20)
+        )
+    )
+
+    // Without the day boundary the window reaches into the next day, so a post-midnight
+    // ingestion joins the previous day's experience (original behavior).
+    @Test
+    fun postMidnightIngestionJoinsPreviousDayWhenCutoffDisabled() {
+        val result = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 15, 0, 30),
+            zone = zone,
+            enforceDayBoundary = false
+        )
+        assertEquals(1, result?.experience?.id)
+    }
+
+    @Test
+    fun postMidnightIngestionStartsNewExperienceWhenCutoffEnabled() {
+        val result = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 15, 0, 30),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun lateNightLastIngestionStillSplitWhenCutoffEnabled() {
+        val session = experience(
+            id = 1,
+            ingestionTimes = listOf(instantOf(2026, 8, 14, 10), instantOf(2026, 8, 14, 23))
+        )
+        val result = findClosestExperience(
+            experiences = listOf(session),
+            selectedInstant = instantOf(2026, 8, 15, 0, 30),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun sameDayIngestionAttachesInBothModes() {
+        val resultDisabled = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 14, 18),
+            zone = zone,
+            enforceDayBoundary = false
+        )
+        val resultEnabled = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 14, 18),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertEquals(1, resultDisabled?.experience?.id)
+        assertEquals(1, resultEnabled?.experience?.id)
+    }
+
+    @Test
+    fun midnightCrossingSessionContinuesWhenCutoffEnabled() {
+        val session = experience(
+            id = 1,
+            ingestionTimes = listOf(instantOf(2026, 8, 14, 22), instantOf(2026, 8, 15, 1))
+        )
+        val result = findClosestExperience(
+            experiences = listOf(session),
+            selectedInstant = instantOf(2026, 8, 15, 2, 30),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertEquals(1, result?.experience?.id)
+    }
+
+    @Test
+    fun singleLateNightDoseAbsorbsNextMorningOnlyWithoutCutoff() {
+        val session = experience(id = 1, ingestionTimes = listOf(instantOf(2026, 8, 14, 22)))
+        val resultDisabled = findClosestExperience(
+            experiences = listOf(session),
+            selectedInstant = instantOf(2026, 8, 15, 1),
+            zone = zone,
+            enforceDayBoundary = false
+        )
+        val resultEnabled = findClosestExperience(
+            experiences = listOf(session),
+            selectedInstant = instantOf(2026, 8, 15, 1),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertEquals(1, resultDisabled?.experience?.id)
+        assertNull(resultEnabled)
+    }
+
+    @Test
+    fun farAwayNextDayStartsNewExperienceInBothModes() {
+        val resultDisabled = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 15, 14),
+            zone = zone,
+            enforceDayBoundary = false
+        )
+        val resultEnabled = findClosestExperience(
+            experiences = listOf(daytimeSession),
+            selectedInstant = instantOf(2026, 8, 15, 14),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertNull(resultDisabled)
+        assertNull(resultEnabled)
+    }
+
+    @Test
+    fun experienceWithoutIngestionsNeverMatches() {
+        val empty = ExperienceWithIngestions(
+            experience = Experience(
+                id = 3,
+                title = "empty",
+                text = "",
+                sortDate = instantOf(2026, 8, 14, 12),
+                location = null
+            ),
+            ingestions = emptyList()
+        )
+        val result = findClosestExperience(
+            experiences = listOf(empty),
+            selectedInstant = instantOf(2026, 8, 14, 13),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
+++ b/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
@@ -209,6 +209,23 @@ class TestFindClosestExperience {
     }
 
     @Test
+    fun nonAdjacentDaySpanMatchesIntermediateDay() {
+        // documented assumption: the ingested days form a contiguous span, so a selection on
+        // the day between two non-adjacent ingestions matches
+        val session = experience(
+            id = 1,
+            ingestionTimes = listOf(instantOf(2026, 8, 14, 12), instantOf(2026, 8, 16, 12))
+        )
+        val result = findClosestExperience(
+            experiences = listOf(session),
+            selectedInstant = instantOf(2026, 8, 15, 12),
+            zone = zone,
+            enforceDayBoundary = true
+        )
+        assertEquals(1, result?.experience?.id)
+    }
+
+    @Test
     fun experienceWithoutIngestionsNeverMatches() {
         val empty = ExperienceWithIngestions(
             experience = Experience(

--- a/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
+++ b/app/src/test/java/com/isaakhanimann/journal/ui/tabs/journal/addingestion/time/TestFindClosestExperience.kt
@@ -184,6 +184,31 @@ class TestFindClosestExperience {
     }
 
     @Test
+    fun dayBoundaryIsEvaluatedInTheProvidedZone() {
+        val session = experience(id = 1, ingestionTimes = listOf(instantOf(2026, 8, 14, 23, 30)))
+        val selected = instantOf(2026, 8, 15, 0, 30)
+        // in UTC these are different calendar days, so the session does not continue
+        assertNull(
+            findClosestExperience(
+                experiences = listOf(session),
+                selectedInstant = selected,
+                zone = ZoneId.of("UTC"),
+                enforceDayBoundary = true
+            )
+        )
+        // in America/Los_Angeles both instants fall on Aug 14, so the session continues
+        assertEquals(
+            1,
+            findClosestExperience(
+                experiences = listOf(session),
+                selectedInstant = selected,
+                zone = ZoneId.of("America/Los_Angeles"),
+                enforceDayBoundary = true
+            )?.experience?.id
+        )
+    }
+
+    @Test
     fun experienceWithoutIngestionsNeverMatches() {
         val empty = ExperienceWithIngestions(
             experience = Experience(


### PR DESCRIPTION
#114

Reporter request: a settings option for a hard midnight cutoff, so an ingestion after midnight starts a new experience instead of joining the previous day's. Default off, preserving the original behavior.

- UserPreferences: key_midnight_cutoff_enabled (default false)
- Settings: toggle with description in the UI card
- findClosestExperience: enforceDayBoundary flag gates the calendar-day constraint; off = original window-only behavior
- i18n en_us/zh_cn/zh_tw
- unit tests covering both modes