### PR TITLE
Fix color palette regression, icon picker, jank, and add 12/24h clock

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,9 +14,9 @@ android {
         applicationId "in.kawaiis.journal"
         minSdk 26
         targetSdk 37
-        versionCode 1100400
+        versionCode 1100500
 
-        versionName "11.4"
+        versionName "11.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -21,6 +21,7 @@
   "settings_substance_colors": "Substance colors",
   "settings_interaction_settings": "Interaction settings",
   "settings_hide_dosage_dots": "Hide dosage dots",
+  "settings_use_24_hour_clock": "Use 24-hour time",
   "settings_app_data": "App data",
   "settings_export_file": "Export file",
   "settings_export_title": "Export?",

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -21,6 +21,7 @@
   "settings_substance_colors": "物质颜色",
   "settings_interaction_settings": "相互作用设置",
   "settings_hide_dosage_dots": "隐藏剂量圆点",
+  "settings_use_24_hour_clock": "使用24小时制",
   "settings_app_data": "应用数据",
   "settings_export_file": "导出文件",
   "settings_export_title": "导出？",

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -21,6 +21,7 @@
   "settings_substance_colors": "物質顏色",
   "settings_interaction_settings": "相互作用設定",
   "settings_hide_dosage_dots": "隱藏劑量圓點",
+  "settings_use_24_hour_clock": "使用24小時制",
   "settings_app_data": "應用程式資料",
   "settings_export_file": "匯出檔案",
   "settings_export_title": "匯出？",

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/entities/AdaptiveColor.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/entities/AdaptiveColor.kt
@@ -1,481 +1,1225 @@
-/*
- * Copyright (c) 2022. Isaak Hanimann.
- * This file is part of PsychonautWiki Journal.
- *
- * PsychonautWiki Journal is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or (at
- * your option) any later version.
- *
- * PsychonautWiki Journal is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with PsychonautWiki Journal.  If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
- */
-
 package com.isaakhanimann.journal.data.room.experiences.entities
 
 import androidx.compose.ui.graphics.Color
 
 enum class AdaptiveColor {
     RED {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 69, blue = 58)
-        } else {
-            Color(red = 255, green = 59, blue = 48)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 69, blue = 58)
+            } else {
+                Color(red = 255, green = 59, blue = 48)
+            }
         }
 
         override val isPreferred = true
     },
     ORANGE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 159, blue = 10)
-        } else {
-            Color(red = 255, green = 149, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 159, blue = 10)
+            } else {
+                Color(red = 255, green = 149, blue = 0)
+            }
         }
 
         override val isPreferred = true
     },
     YELLOW {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 214, blue = 10)
-        } else {
-            Color(red = 255, green = 204, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 214, blue = 10)
+            } else {
+                Color(red = 255, green = 204, blue = 0)
+            }
         }
 
         override val isPreferred = true
     },
     GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 48, green = 209, blue = 88)
-        } else {
-            Color(red = 52, green = 199, blue = 89)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 48, green = 209, blue = 88)
+            } else {
+                Color(red = 52, green = 199, blue = 89)
+            }
         }
 
         override val isPreferred = true
     },
     MINT {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 102, green = 212, blue = 207)
-        } else {
-            Color(red = 0, green = 199, blue = 190)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 102, green = 212, blue = 207)
+            } else {
+                Color(red = 0, green = 199, blue = 190)
+            }
         }
 
         override val isPreferred = true
     },
     TEAL {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 64, green = 200, blue = 224)
-        } else {
-            Color(red = 48, green = 176, blue = 199)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 64, green = 200, blue = 224)
+            } else {
+                Color(red = 48, green = 176, blue = 199)
+            }
         }
 
         override val isPreferred = true
     },
     CYAN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 100, green = 210, blue = 255)
-        } else {
-            Color(red = 50, green = 173, blue = 230)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 100, green = 210, blue = 255)
+            } else {
+                Color(red = 50, green = 173, blue = 230)
+            }
         }
 
         override val isPreferred = true
     },
     BLUE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 10, green = 132, blue = 255)
-        } else {
-            Color(red = 0, green = 122, blue = 255)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 10, green = 132, blue = 255)
+            } else {
+                Color(red = 0, green = 122, blue = 255)
+            }
         }
 
         override val isPreferred = true
     },
     INDIGO {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 94, green = 92, blue = 230)
-        } else {
-            Color(red = 88, green = 86, blue = 214)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 94, green = 92, blue = 230)
+            } else {
+                Color(red = 88, green = 86, blue = 214)
+            }
         }
 
         override val isPreferred = true
     },
     PURPLE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 191, green = 90, blue = 242)
-        } else {
-            Color(red = 175, green = 82, blue = 222)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 191, green = 90, blue = 242)
+            } else {
+                Color(red = 175, green = 82, blue = 222)
+            }
         }
 
         override val isPreferred = true
     },
     PINK {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 55, blue = 95)
-        } else {
-            Color(red = 255, green = 45, blue = 85)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 55, blue = 95)
+            } else {
+                Color(red = 255, green = 45, blue = 85)
+            }
         }
 
         override val isPreferred = true
     },
     BROWN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 172, green = 142, blue = 104)
-        } else {
-            Color(red = 162, green = 132, blue = 94)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 172, green = 142, blue = 104)
+            } else {
+                Color(red = 162, green = 132, blue = 94)
+            }
         }
 
         override val isPreferred = true
     },
     FIRE_ENGINE_RED {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 237, green = 43, blue = 42)
-        } else {
-            Color(red = 237, green = 14, blue = 6)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 237, green = 43, blue = 42)
+            } else {
+                Color(red = 237, green = 14, blue = 6)
+            }
         }
 
         override val isPreferred = false
     },
     CORAL {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 131, blue = 121)
-        } else {
-            Color(red = 180, green = 92, blue = 85)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 131, blue = 121)
+            } else {
+                Color(red = 180, green = 92, blue = 85)
+            }
         }
 
         override val isPreferred = false
     },
     TOMATO {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 99, blue = 71)
-        } else {
-            Color(red = 180, green = 69, blue = 50)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 99, blue = 71)
+            } else {
+                Color(red = 180, green = 69, blue = 50)
+            }
         }
 
         override val isPreferred = false
     },
     CINNABAR {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 227, green = 36, blue = 0)
-        } else {
-            Color(red = 227, green = 36, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 227, green = 36, blue = 0)
+            } else {
+                Color(red = 227, green = 36, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     RUST {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 199, green = 81, blue = 58)
-        } else {
-            Color(red = 199, green = 81, blue = 58)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 199, green = 81, blue = 58)
+            } else {
+                Color(red = 199, green = 81, blue = 58)
+            }
         }
 
         override val isPreferred = false
     },
     ORANGE_RED {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 69, blue = 0)
-        } else {
-            Color(red = 205, green = 55, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 69, blue = 0)
+            } else {
+                Color(red = 205, green = 55, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     AUBURN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 217, green = 80, blue = 0)
-        } else {
-            Color(red = 173, green = 62, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 217, green = 80, blue = 0)
+            } else {
+                Color(red = 173, green = 62, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     SADDLE_BROWN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 191, green = 95, blue = 25)
-        } else {
-            Color(red = 139, green = 69, blue = 19)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 191, green = 95, blue = 25)
+            } else {
+                Color(red = 139, green = 69, blue = 19)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_ORANGE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 140, blue = 0)
-        } else {
-            Color(red = 155, green = 84, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 140, blue = 0)
+            } else {
+                Color(red = 155, green = 84, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_GOLD {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 169, green = 104, blue = 0)
-        } else {
-            Color(red = 169, green = 104, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 169, green = 104, blue = 0)
+            } else {
+                Color(red = 169, green = 104, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     KHAKI {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 203, green = 183, blue = 137)
-        } else {
-            Color(red = 128, green = 114, blue = 86)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 203, green = 183, blue = 137)
+            } else {
+                Color(red = 128, green = 114, blue = 86)
+            }
         }
 
         override val isPreferred = false
     },
     BRONZE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 167, green = 123, blue = 0)
-        } else {
-            Color(red = 120, green = 87, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 167, green = 123, blue = 0)
+            } else {
+                Color(red = 120, green = 87, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     GOLD {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 215, blue = 0)
-        } else {
-            Color(red = 130, green = 109, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 215, blue = 0)
+            } else {
+                Color(red = 130, green = 109, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     OLIVE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 141, green = 134, blue = 0)
-        } else {
-            Color(red = 102, green = 97, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 141, green = 134, blue = 0)
+            } else {
+                Color(red = 102, green = 97, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     OLIVE_DRAB {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 154, green = 166, blue = 14)
-        } else {
-            Color(red = 111, green = 118, blue = 8)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 154, green = 166, blue = 14)
+            } else {
+                Color(red = 111, green = 118, blue = 8)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_OLIVE_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 105, green = 133, blue = 58)
-        } else {
-            Color(red = 85, green = 107, blue = 47)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 105, green = 133, blue = 58)
+            } else {
+                Color(red = 85, green = 107, blue = 47)
+            }
         }
 
         override val isPreferred = false
     },
     MOSS_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 102, green = 156, blue = 53)
-        } else {
-            Color(red = 79, green = 122, blue = 40)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 102, green = 156, blue = 53)
+            } else {
+                Color(red = 79, green = 122, blue = 40)
+            }
         }
 
         override val isPreferred = false
     },
     LIME_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 0, green = 255, blue = 0)
-        } else {
-            Color(red = 0, green = 130, blue = 0)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 0, green = 255, blue = 0)
+            } else {
+                Color(red = 0, green = 130, blue = 0)
+            }
         }
 
         override val isPreferred = false
     },
     LIME {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 50, green = 205, blue = 50)
-        } else {
-            Color(red = 32, green = 130, blue = 32)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 50, green = 205, blue = 50)
+            } else {
+                Color(red = 32, green = 130, blue = 32)
+            }
         }
 
         override val isPreferred = false
     },
     FOREST_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 34, green = 139, blue = 34)
-        } else {
-            Color(red = 28, green = 114, blue = 28)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 34, green = 139, blue = 34)
+            } else {
+                Color(red = 28, green = 114, blue = 28)
+            }
         }
 
         override val isPreferred = false
     },
     SEA_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 46, green = 139, blue = 87)
-        } else {
-            Color(red = 38, green = 114, blue = 71)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 46, green = 139, blue = 87)
+            } else {
+                Color(red = 38, green = 114, blue = 71)
+            }
         }
 
         override val isPreferred = false
     },
     JUNGLE_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 3, green = 136, blue = 88)
-        } else {
-            Color(red = 3, green = 136, blue = 88)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 3, green = 136, blue = 88)
+            } else {
+                Color(red = 3, green = 136, blue = 88)
+            }
         }
 
         override val isPreferred = false
     },
     LIGHT_SEA_GREEN {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 32, green = 178, blue = 170)
-        } else {
-            Color(red = 22, green = 128, blue = 122)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 32, green = 178, blue = 170)
+            } else {
+                Color(red = 22, green = 128, blue = 122)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_TURQUOISE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 0, green = 206, blue = 209)
-        } else {
-            Color(red = 0, green = 131, blue = 134)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 0, green = 206, blue = 209)
+            } else {
+                Color(red = 0, green = 131, blue = 134)
+            }
         }
 
         override val isPreferred = false
     },
     DODGER_BLUE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 30, green = 144, blue = 255)
-        } else {
-            Color(red = 24, green = 116, blue = 205)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 30, green = 144, blue = 255)
+            } else {
+                Color(red = 24, green = 116, blue = 205)
+            }
         }
 
         override val isPreferred = false
     },
     ROYAL_BLUE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 72, green = 117, blue = 251)
-        } else {
-            Color(red = 65, green = 105, blue = 225)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 72, green = 117, blue = 251)
+            } else {
+                Color(red = 65, green = 105, blue = 225)
+            }
         }
 
         override val isPreferred = false
     },
     DEEP_LAVENDER {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 135, green = 78, blue = 254)
-        } else {
-            Color(red = 135, green = 78, blue = 254)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 135, green = 78, blue = 254)
+            } else {
+                Color(red = 135, green = 78, blue = 254)
+            }
         }
 
         override val isPreferred = false
     },
     BLUE_VIOLET {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 166, green = 73, blue = 252)
-        } else {
-            Color(red = 138, green = 43, blue = 226)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 166, green = 73, blue = 252)
+            } else {
+                Color(red = 138, green = 43, blue = 226)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_VIOLET {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 162, green = 76, blue = 210)
-        } else {
-            Color(red = 148, green = 0, blue = 211)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 162, green = 76, blue = 210)
+            } else {
+                Color(red = 148, green = 0, blue = 211)
+            }
         }
 
         override val isPreferred = false
     },
     HELIOTROPE {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 151, green = 93, blue = 175)
-        } else {
-            Color(red = 151, green = 93, blue = 175)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 151, green = 93, blue = 175)
+            } else {
+                Color(red = 151, green = 93, blue = 175)
+            }
         }
 
         override val isPreferred = false
     },
     BYZANTIUM {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 190, green = 56, blue = 243)
-        } else {
-            Color(red = 153, green = 41, blue = 189)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 190, green = 56, blue = 243)
+            } else {
+                Color(red = 153, green = 41, blue = 189)
+            }
         }
 
         override val isPreferred = false
     },
     MAGENTA {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 0, blue = 255)
-        } else {
-            Color(red = 205, green = 0, blue = 205)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 0, blue = 255)
+            } else {
+                Color(red = 205, green = 0, blue = 205)
+            }
         }
 
         override val isPreferred = false
     },
     DARK_MAGENTA {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 217, green = 0, blue = 217)
-        } else {
-            Color(red = 139, green = 0, blue = 139)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 217, green = 0, blue = 217)
+            } else {
+                Color(red = 139, green = 0, blue = 139)
+            }
         }
 
         override val isPreferred = false
     },
     FUCHSIA {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 214, green = 68, blue = 146)
-        } else {
-            Color(red = 189, green = 60, blue = 129)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 214, green = 68, blue = 146)
+            } else {
+                Color(red = 189, green = 60, blue = 129)
+            }
         }
 
         override val isPreferred = false
     },
     DEEP_PINK {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 20, blue = 147)
-        } else {
-            Color(red = 205, green = 16, blue = 117)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 20, blue = 147)
+            } else {
+                Color(red = 205, green = 16, blue = 117)
+            }
         }
 
         override val isPreferred = false
     },
     GRAYISH_MAGENTA {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 161, green = 96, blue = 128)
-        } else {
-            Color(red = 161, green = 96, blue = 128)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 161, green = 96, blue = 128)
+            } else {
+                Color(red = 161, green = 96, blue = 128)
+            }
         }
 
         override val isPreferred = false
     },
     HOT_PINK {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 255, green = 105, blue = 180)
-        } else {
-            Color(red = 180, green = 74, blue = 126)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 105, blue = 180)
+            } else {
+                Color(red = 180, green = 74, blue = 126)
+            }
         }
 
         override val isPreferred = false
     },
     JAZZBERRY_JAM {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 230, green = 59, blue = 122)
-        } else {
-            Color(red = 185, green = 45, blue = 93)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 230, green = 59, blue = 122)
+            } else {
+                Color(red = 185, green = 45, blue = 93)
+            }
         }
 
         override val isPreferred = false
     },
     MAROON {
-        override fun getComposeColor(isDarkTheme: Boolean): Color = if (isDarkTheme) {
-            Color(red = 187, green = 82, blue = 99)
-        } else {
-            Color(red = 190, green = 49, blue = 68)
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 187, green = 82, blue = 99)
+            } else {
+                Color(red = 190, green = 49, blue = 68)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    GARNET_NOIR {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 145, green = 71, blue = 71)
+            } else {
+                Color(red = 102, green = 0, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SMOKED_ROSEWOOD {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 120, green = 108, blue = 108)
+            } else {
+                Color(red = 68, green = 51, blue = 51)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ROSE_QUARTZ {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 243, green = 194, blue = 194)
+            } else {
+                Color(red = 189, green = 135, blue = 135)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SUNSET_APRICOT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 194, blue = 145)
+            } else {
+                Color(red = 200, green = 134, blue = 80)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    HONEY_SAFFRON {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 231, blue = 157)
+            } else {
+                Color(red = 170, green = 147, blue = 80)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    MIDNIGHT_OLIVE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 108, green = 108, blue = 71)
+            } else {
+                Color(red = 51, green = 51, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    NEON_LEMON {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 243, green = 255, blue = 145)
+            } else {
+                Color(red = 145, green = 155, blue = 63)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ELECTRIC_CHARTREUSE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 218, green = 255, blue = 71)
+            } else {
+                Color(red = 129, green = 160, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    MOSS_APPLE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 157, green = 206, blue = 71)
+            } else {
+                Color(red = 105, green = 165, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SPRING_BUD {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 194, green = 255, blue = 145)
+            } else {
+                Color(red = 109, green = 163, blue = 66)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    PALE_PISTACHIO {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 218, green = 255, blue = 194)
+            } else {
+                Color(red = 127, green = 158, blue = 105)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SILVER_SAGE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 169, green = 194, blue = 169)
+            } else {
+                Color(red = 125, green = 157, blue = 125)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    FROSTED_MINT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 243, green = 255, blue = 243)
+            } else {
+                Color(red = 141, green = 151, blue = 141)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    BLACK_PINE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 71, green = 96, blue = 84)
+            } else {
+                Color(red = 0, green = 34, blue = 17)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SEAFOAM_JADE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 157, green = 231, blue = 194)
+            } else {
+                Color(red = 88, green = 163, blue = 126)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    TROPICAL_AQUA {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 71, green = 255, blue = 206)
+            } else {
+                Color(red = 0, green = 169, blue = 125)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    DEEP_HARBOR_BLUE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 71, green = 108, blue = 157)
+            } else {
+                Color(red = 0, green = 51, blue = 119)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    STORM_SLATE_BLUE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 120, green = 133, blue = 157)
+            } else {
+                Color(red = 68, green = 85, blue = 119)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ABYSSAL_NAVY {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 87, green = 87, blue = 117)
+            } else {
+                Color(red = 0, green = 0, blue = 34)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    MIDNIGHT_COBALT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 82, green = 82, blue = 153)
+            } else {
+                Color(red = 0, green = 0, blue = 85)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SATURATED_COBALT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 74, green = 74, blue = 189)
+            } else {
+                Color(red = 0, green = 0, blue = 153)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    LASER_BLUE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 71, green = 71, blue = 255)
+            } else {
+                Color(red = 0, green = 0, blue = 255)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    DUSTY_PERIWINKLE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 182, green = 182, blue = 194)
+            } else {
+                Color(red = 147, green = 147, blue = 164)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SOFT_PERIWINKLE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 194, green = 194, blue = 243)
+            } else {
+                Color(red = 143, green = 143, blue = 201)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    COTTON_CANDY_MAGENTA {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 194, blue = 255)
+            } else {
+                Color(red = 191, green = 126, blue = 191)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    LILAC_MIST {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 231, blue = 255)
+            } else {
+                Color(red = 164, green = 142, blue = 164)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ELECTRIC_ORCHID {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 157, blue = 243)
+            } else {
+                Color(red = 222, green = 104, blue = 208)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    DEEP_PLUM_WINE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 133, green = 71, blue = 120)
+            } else {
+                Color(red = 85, green = 0, blue = 68)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    RADIANT_MULBERRY {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 231, green = 84, blue = 194)
+            } else {
+                Color(red = 221, green = 17, blue = 170)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    BLACK_CHERRY {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 126, green = 74, blue = 88)
+            } else {
+                Color(red = 68, green = 0, blue = 17)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ACID_LIME {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 139, green = 184, blue = 76)
+            } else {
+                Color(red = 94, green = 156, blue = 7)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    WASABI_ZING {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 156, green = 225, blue = 71)
+            } else {
+                Color(red = 92, green = 167, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    CITRUS_LEAF {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 161, green = 205, blue = 107)
+            } else {
+                Color(red = 110, green = 163, blue = 43)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    VERDANT_CHARTREUSE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 157, green = 222, blue = 119)
+            } else {
+                Color(red = 95, green = 166, blue = 53)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    KIWI_PUNCH {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 111, green = 178, blue = 75)
+            } else {
+                Color(red = 55, green = 148, blue = 5)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    PERIDOT_FLARE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 126, green = 231, blue = 74)
+            } else {
+                Color(red = 59, green = 170, blue = 2)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    APPLE_ZEST {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 128, green = 195, blue = 102)
+            } else {
+                Color(red = 77, green = 168, blue = 41)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    LIME_SPARK {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 101, green = 198, blue = 84)
+            } else {
+                Color(red = 40, green = 172, blue = 17)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    HERBAL_NEON {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 102, green = 231, blue = 107)
+            } else {
+                Color(red = 33, green = 172, blue = 38)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    CLOVER_GLOW {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 84, green = 183, blue = 91)
+            } else {
+                Color(red = 18, green = 155, blue = 27)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    AUREATE_GOLD {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 195, blue = 31)
+            } else {
+                Color(red = 153, green = 117, blue = 18)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SAFFRON_BLAZE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 231, blue = 10)
+            } else {
+                Color(red = 166, green = 150, blue = 7)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    AMBER_BURST {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 255, green = 247, blue = 25)
+            } else {
+                Color(red = 115, green = 111, blue = 11)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    MARIGOLD_FLARE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 247, green = 255, blue = 5)
+            } else {
+                Color(red = 143, green = 148, blue = 3)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SUNLIT_OCHRE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 233, green = 255, blue = 31)
+            } else {
+                Color(red = 116, green = 128, blue = 15)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    BRONZED_HONEY {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 208, green = 255, blue = 0)
+            } else {
+                Color(red = 94, green = 115, blue = 0)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    CELESTIAL_AZURE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 43, green = 167, blue = 255)
+            } else {
+                Color(red = 39, green = 152, blue = 232)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    COBALT_SURGE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 89, green = 183, blue = 255)
+            } else {
+                Color(red = 69, green = 141, blue = 196)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    DEEP_SKY_CERULEAN {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 13, green = 106, blue = 255)
+            } else {
+                Color(red = 4, green = 37, blue = 89)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ELECTRIC_SAPPHIRE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 3, green = 91, blue = 255)
+            } else {
+                Color(red = 1, green = 52, blue = 145)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    MIDNIGHT_AZURE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 103, green = 89, blue = 255)
+            } else {
+                Color(red = 98, green = 85, blue = 242)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ULTRAMARINE_GLOW {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 79, green = 43, blue = 255)
+            } else {
+                Color(red = 40, green = 22, blue = 130)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    AZURE_TIDE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 20, green = 185, blue = 255)
+            } else {
+                Color(red = 9, green = 78, blue = 107)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    CERULEAN_SURGE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 10, green = 173, blue = 255)
+            } else {
+                Color(red = 5, green = 88, blue = 130)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    COBALT_CURRENT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 5, green = 155, blue = 255)
+            } else {
+                Color(red = 2, green = 65, blue = 107)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    SAPPHIRE_WAVE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 5, green = 138, blue = 255)
+            } else {
+                Color(red = 2, green = 62, blue = 115)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    DEEP_AZURE_EDGE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 0, green = 115, blue = 255)
+            } else {
+                Color(red = 0, green = 48, blue = 107)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ROYAL_COBALT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 0, green = 98, blue = 255)
+            } else {
+                Color(red = 0, green = 47, blue = 122)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    ELECTRIC_COBALT {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 5, green = 80, blue = 255)
+            } else {
+                Color(red = 3, green = 49, blue = 156)
+            }
+        }
+
+        override val isPreferred = false
+    },
+    NIGHT_AZURE {
+        override fun getComposeColor(isDarkTheme: Boolean): Color {
+            return if (isDarkTheme) {
+                Color(red = 5, green = 59, blue = 255)
+            } else {
+                Color(red = 2, green = 25, blue = 107)
+            }
         }
 
         override val isPreferred = false

--- a/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
@@ -26,6 +26,12 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.isaakhanimann.journal.ui.notifications.Notifications
 import com.isaakhanimann.journal.ui.notifications.TimeCapsuleWorker
+import com.isaakhanimann.journal.ui.tabs.settings.combinations.UserPreferences
+import com.isaakhanimann.journal.ui.utils.TimeFormat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import dagger.hilt.android.HiltAndroidApp
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -36,6 +42,11 @@ class JournalApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
+    @Inject
+    lateinit var userPreferences: UserPreferences
+
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -43,6 +54,10 @@ class JournalApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        TimeFormat.refreshSystemDefault(this)
+        applicationScope.launch {
+            userPreferences.use24HourClockFlow.collect { TimeFormat.setUserOverride(it) }
+        }
         Notifications.createChannels(this)
         // Daily time-capsule check: "this day last year".
         val request = PeriodicWorkRequestBuilder<TimeCapsuleWorker>(1, TimeUnit.DAYS).build()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/notifications/Notifications.kt
@@ -81,7 +81,7 @@ object Notifications {
     ) {
         if (!hasNotificationPermission(context)) return
         val timeText = ingestionTime.atZone(ZoneId.systemDefault())
-            .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"))
+            .format(java.time.format.DateTimeFormatter.ofPattern(com.isaakhanimann.journal.ui.utils.TimeFormat.timePattern))
         val text = I18n.translate(
             context,
             "effect_notification_text",

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -337,7 +337,10 @@ fun JournalScreen(
                                 HorizontalDivider()
                             }
                         }
-                        items(experiences) { experienceWithIngestions ->
+                        items(
+                            experiences,
+                            key = { it.experience.id }
+                        ) { experienceWithIngestions ->
                             ExperienceRow(
                                 experienceWithIngestions,
                                 navigateToExperienceScreen = {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalViewModel.kt
@@ -34,10 +34,12 @@ import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepositor
 import com.isaakhanimann.journal.ui.tabs.settings.combinations.UserPreferences
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -206,6 +208,7 @@ class JournalViewModel @Inject constructor(
                 }
                 return@combine experiencesWithIngestions
             }
+            .flowOn(Dispatchers.Default)
             .stateIn(
                 initialValue = emptyList(),
                 scope = viewModelScope,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/components/ExperienceRow.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/components/ExperienceRow.kt
@@ -88,17 +88,20 @@ fun ExperienceRow(
         val context = LocalContext.current
         val currentView = LocalView.current
         val coroutineScope = rememberCoroutineScope()
-        val ingestions = experienceWithIngestionsCompanionsAndRatings.ingestionsWithCompanions.sortedBy { it.ingestion.time }
         val experience = experienceWithIngestionsCompanionsAndRatings.experience
-        val timedNotes = rowViewModel.getTimedNotes(
-            experience.id
-        ).collectAsState(initial = emptyList()).value
+        val ingestions = remember(experienceWithIngestionsCompanionsAndRatings) {
+            experienceWithIngestionsCompanionsAndRatings.ingestionsWithCompanions.sortedBy { it.ingestion.time }
+        }
+        val timedNotesFlow = remember(experience.id) { rowViewModel.getTimedNotes(experience.id) }
+        val timedNotes = timedNotesFlow.collectAsState(initial = emptyList()).value
         val substanceRepo = rowViewModel.substanceRepo
         val interactionChecker = rowViewModel.interactionChecker
         val getSubstanceDisplayName = rowViewModel.substanceRepo::getDisplayName
         val achievements = rowViewModel.achievementsFlow.collectAsState().value
 
-        val cardData = prepareShareableExperienceCardData(
+        // Only needed when the user taps share, so it's built on demand rather than
+        // on every row recomposition (substance/dose lookups + interaction checks are not cheap).
+        fun buildCardData() = prepareShareableExperienceCardData(
             substanceRepo = substanceRepo,
             interactionChecker = interactionChecker,
             ownerUserName = ownerUserName,
@@ -192,6 +195,7 @@ fun ExperienceRow(
                 try {
                     val activity = context as? androidx.activity.ComponentActivity
                     if (activity != null) {
+                        val cardData = buildCardData()
                         val bitmap = renderComposeViewToBitmap(
                             context = context,
                             widthPx = 1080,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeRelativeToStartText.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.isaakhanimann.journal.ui.tabs.journal.components.roundToOneDecimal
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import com.isaakhanimann.journal.ui.utils.getWeekdayTimeText
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -43,7 +44,7 @@ fun TimeRelativeToStartText(
         duration.toHours() > 1 -> "+ ${roundToOneDecimal(duration.toMinutes().toDouble() / 60.0)} h"
         duration.toMinutes() > 0 -> "+ ${duration.toMinutes()} min"
         duration.toMillis() > 0 -> "+ ${(duration.toMillis() / 1000).toInt()} s"
-        else -> time.getStringOfPattern("EEE HH:mm")
+        else -> time.getWeekdayTimeText()
     }
     Text(
         text = relativeTime,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/components/TimeText.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import com.isaakhanimann.journal.ui.utils.getWeekdayTimeText
 import java.time.Instant
 
 @Composable
@@ -33,7 +34,7 @@ fun TimeText(
 ) {
     when (timeDisplayOption) {
         TimeDisplayOption.REGULAR -> {
-            val timeString = time.getStringOfPattern("EEE HH:mm")
+            val timeString = time.getWeekdayTimeText()
             Text(
                 text = timeString,
                 style = style
@@ -53,7 +54,7 @@ fun TimeText(
             )
         }
         TimeDisplayOption.TIME_BETWEEN -> {
-            val timeString = time.getStringOfPattern("EEE HH:mm")
+            val timeString = time.getWeekdayTimeText()
             Text(
                 text = timeString,
                 style = style

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/drawables/AxisDrawable.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/experience/timeline/drawables/AxisDrawable.kt
@@ -18,6 +18,7 @@
 
 package com.isaakhanimann.journal.ui.tabs.journal.experience.timeline.drawables
 
+import com.isaakhanimann.journal.ui.utils.TimeFormat
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
 import java.time.Duration
 import java.time.Instant
@@ -48,7 +49,7 @@ data class AxisDrawable(
             val distanceInSec = Duration.between(startTime, it).seconds
             FullHour(
                 distanceFromStart = distanceInSec * pixelsPerSec,
-                label = it.getStringOfPattern("HH")
+                label = it.getStringOfPattern(TimeFormat.hourPattern)
             )
         }
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/timecapsule/TimeCapsuleScreen.kt
@@ -30,6 +30,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsTimedNotesAndRatings
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import com.isaakhanimann.journal.ui.utils.getTimeText
 
 /**
  * "This day last year" recap: the experiences recorded exactly one year ago.
@@ -103,7 +104,7 @@ fun TimeCapsuleScreen(
                             .padding(horizontal = 16.dp, vertical = 12.dp)
                     ) {
                         Text(
-                            text = item.experience.sortDate.getStringOfPattern("HH:mm"),
+                            text = item.experience.sortDate.getTimeText(),
                             style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/substance/SubstanceScreen.kt
@@ -90,6 +90,7 @@ import com.isaakhanimann.journal.ui.theme.verticalPaddingCards
 import com.isaakhanimann.journal.ui.utils.administrationRouteKey
 import com.isaakhanimann.journal.ui.utils.getInstant
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import com.isaakhanimann.journal.ui.utils.getTimeText
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.math.absoluteValue
@@ -384,7 +385,7 @@ fun SubstanceScreen(
                             TimePickerButton(
                                 localDateTime = ingestionTime,
                                 onChange = { ingestionTime = it },
-                                timeString = ingestionTime.getStringOfPattern("HH:mm"),
+                                timeString = ingestionTime.getTimeText(),
                                 hasOutline = false
                             )
                             val isTimeALotDifferentToNow = ChronoUnit.MINUTES.between(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/IconPickerScreen.kt
@@ -62,7 +62,9 @@ data class IconOption(
     val label: String,
     val backgroundColor: Color,
     val iconRes: Int,
-    val aliasName: String
+    val aliasName: String,
+    /** True for the alias the manifest ships with android:enabled="true". */
+    val isDefault: Boolean = false
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,7 +88,8 @@ fun IconPickerScreen() {
             label = i18n("settings_icon_springwind"),
             backgroundColor = Color(0xFFFF8C94),
             iconRes = R.drawable.ic_springwind_foreground,
-            aliasName = ".MainActivity_SpringWind"
+            aliasName = ".MainActivity_SpringWind",
+            isDefault = true
         )
     )
 
@@ -98,7 +101,7 @@ fun IconPickerScreen() {
     }
 
     var selectedKey by remember {
-        mutableStateOf(getCurrentIconKey(pm, aliases))
+        mutableStateOf(getCurrentIconKey(pm, iconOptions, aliases))
     }
     var isSwitching by remember { mutableStateOf(false) }
 
@@ -149,7 +152,10 @@ fun IconPickerScreen() {
             }
 
             Text(
-                text = i18n("settings_icon_current", mapOf("name" to selectedKey)),
+                text = i18n(
+                    "settings_icon_current",
+                    mapOf("name" to (iconOptions.first { it.key == selectedKey }.label))
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -157,16 +163,28 @@ fun IconPickerScreen() {
     }
 }
 
-private fun getCurrentIconKey(pm: PackageManager, aliases: Map<String, ComponentName>): String {
-    aliases.forEach { (key, component) ->
-        try {
-            val state = pm.getComponentEnabledSetting(component)
-            if (state == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
-                return key
-            }
-        } catch (_: Exception) { }
+private fun getCurrentIconKey(
+    pm: PackageManager,
+    options: List<IconOption>,
+    aliases: Map<String, ComponentName>
+): String {
+    val defaultKey = options.first { it.isDefault }.key
+    options.forEach { option ->
+        val component = aliases[option.key] ?: return@forEach
+        val state = try {
+            pm.getComponentEnabledSetting(component)
+        } catch (_: Exception) {
+            return@forEach
+        }
+        when (state) {
+            PackageManager.COMPONENT_ENABLED_STATE_ENABLED -> return option.key
+            // Until an alias is explicitly toggled it stays in DEFAULT, which means
+            // "whatever the manifest declares" - only ever true for the default alias.
+            PackageManager.COMPONENT_ENABLED_STATE_DEFAULT ->
+                if (option.isDefault) return option.key
+        }
     }
-    return aliases.keys.first()
+    return defaultKey
 }
 
 private fun switchIcon(
@@ -174,20 +192,24 @@ private fun switchIcon(
     aliases: Map<String, ComponentName>,
     enableKey: String
 ): Boolean {
+    val target = aliases[enableKey] ?: return false
     return try {
-        aliases.values.forEach { component ->
-            pm.setComponentEnabledSetting(
-                component,
-                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-                0
-            )
-        }
-        val target = aliases[enableKey] ?: return false
+        // Enable the new alias before disabling the old one, otherwise there is a
+        // moment with no launcher entry at all and some launchers drop the icon for good.
         pm.setComponentEnabledSetting(
             target,
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-            0
+            PackageManager.DONT_KILL_APP
         )
+        aliases.forEach { (key, component) ->
+            if (key != enableKey) {
+                pm.setComponentEnabledSetting(
+                    component,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP
+                )
+            }
+        }
         true
     } catch (e: Exception) {
         e.printStackTrace()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -95,6 +95,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.isaakhanimann.journal.data.achievement.AchievementLogoButton
 import com.isaakhanimann.journal.localization.I18n
+import com.isaakhanimann.journal.ui.utils.TimeFormat
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardWithTitle
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
@@ -155,6 +156,9 @@ fun SettingsScreen(
         saveAreSubstanceHeightsIndependent = viewModel::saveAreSubstanceHeightsIndependent,
         isMidnightCutoffEnabled = viewModel.isMidnightCutoffEnabledFlow.collectAsState().value,
         saveMidnightCutoffEnabled = viewModel::saveMidnightCutoffEnabled,
+        use24HourClock = viewModel.use24HourClockFlow.collectAsState().value
+            ?: TimeFormat.systemDefaultIs24Hour(),
+        saveUse24HourClock = viewModel::saveUse24HourClock,
     )
 }
 
@@ -193,6 +197,8 @@ fun SettingsScreen(
     saveAreSubstanceHeightsIndependent: (Boolean) -> Unit,
     isMidnightCutoffEnabled: Boolean,
     saveMidnightCutoffEnabled: (Boolean) -> Unit,
+    use24HourClock: Boolean = true,
+    saveUse24HourClock: (Boolean) -> Unit = {},
 ) {
     Scaffold(
         topBar = {
@@ -268,6 +274,22 @@ fun SettingsScreen(
                     text = i18n("settings_icon_title")
                 ) {
                     navigateToIconPicker()
+                }
+
+                HorizontalDivider()
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = horizontalPadding),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = i18n("settings_use_24_hour_clock"))
+                    Switch(
+                        checked = use24HourClock,
+                        onCheckedChange = saveUse24HourClock
+                    )
                 }
 
                 HorizontalDivider()

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
@@ -77,6 +77,16 @@ class SettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000)
     )
 
+    fun saveUse24HourClock(value: Boolean) = viewModelScope.launch {
+        userPreferences.saveUse24HourClock(value)
+    }
+
+    val use24HourClockFlow = userPreferences.use24HourClockFlow.stateIn(
+        initialValue = null,
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
+
     fun saveOpenLinkInBrowser(value: Boolean) {
         viewModelScope.launch {
             userPreferences.saveOpenLinkInBrowser(value)

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -55,6 +55,7 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         val KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT = booleanPreferencesKey("KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT")
         val KEY_IS_TIMELINE_HIDDEN = booleanPreferencesKey("KEY_IS_TIMELINE_HIDDEN")
         val KEY_MIDNIGHT_CUTOFF_ENABLED = booleanPreferencesKey("key_midnight_cutoff_enabled")
+        val KEY_USE_24_HOUR_CLOCK = booleanPreferencesKey("key_use_24_hour_clock")
     }
 
     suspend fun saveTimeDisplayOption(value: SavedTimeDisplayOption) {
@@ -143,6 +144,18 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
     val areDosageDotsHiddenFlow: Flow<Boolean> = dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.KEY_HIDE_DOSAGE_DOTS] ?: false
+        }
+
+    suspend fun saveUse24HourClock(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.KEY_USE_24_HOUR_CLOCK] = value
+        }
+    }
+
+    /** Null until the user chooses, in which case the system clock setting is followed. */
+    val use24HourClockFlow: Flow<Boolean?> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.KEY_USE_24_HOUR_CLOCK]
         }
 
     suspend fun saveAreSubstanceHeightsIndependent(value: Boolean) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/substancecompanion/SubstanceCompanionScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/substancecompanion/SubstanceCompanionScreen.kt
@@ -66,6 +66,7 @@ import com.isaakhanimann.journal.ui.tabs.search.substance.roa.ToleranceSection
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.administrationRouteKey
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
+import com.isaakhanimann.journal.ui.utils.getTimeText
 
 @Composable
 fun SubstanceCompanionScreen(
@@ -251,7 +252,7 @@ fun IngestionRow(
             }
         }
         Text(text = text, style = MaterialTheme.typography.titleSmall)
-        val dateString = ingestionAndCustomUnit.ingestion.time.getStringOfPattern("HH:mm")
+        val dateString = ingestionAndCustomUnit.ingestion.time.getTimeText()
         Text(text = dateString)
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/utils/TimeFormat.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/utils/TimeFormat.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022. Isaak Hanimann.
+ * This file is part of PsychonautWiki Journal.
+ *
+ * PsychonautWiki Journal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ */
+
+package com.isaakhanimann.journal.ui.utils
+
+import android.content.Context
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Process-wide clock format. Reads from composition subscribe to changes, reads from
+ * view models and drawables just see the current value.
+ */
+object TimeFormat {
+
+    private var systemUses24Hour by mutableStateOf(true)
+    private var overrideIs24Hour by mutableStateOf<Boolean?>(null)
+
+    /** Null until the user picks explicitly, in which case the system setting is followed. */
+    val is24Hour: Boolean
+        get() = overrideIs24Hour ?: systemUses24Hour
+
+    val timePattern: String
+        get() = if (is24Hour) "HH:mm" else "h:mm a"
+
+    val hourPattern: String
+        get() = if (is24Hour) "HH" else "h a"
+
+    fun refreshSystemDefault(context: Context) {
+        systemUses24Hour = android.text.format.DateFormat.is24HourFormat(context)
+    }
+
+    fun setUserOverride(value: Boolean?) {
+        overrideIs24Hour = value
+    }
+
+    fun systemDefaultIs24Hour(): Boolean = systemUses24Hour
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/utils/getDateFromString.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/utils/getDateFromString.kt
@@ -18,13 +18,11 @@
 
 package com.isaakhanimann.journal.ui.utils
 
-import java.text.DateFormat
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.Date
 import java.util.Locale
 
 fun getInstant(year: Int, month: Int, day: Int, hourOfDay: Int, minute: Int): Instant? {
@@ -50,11 +48,14 @@ fun Instant.getShortTimeWithWeekdayText(): String {
     return getShortWeekdayText() + " " + getShortTimeText()
 }
 
-fun Instant.getShortTimeText(): String {
-    val timeFormat: DateFormat = DateFormat.getTimeInstance(DateFormat.SHORT, Locale.getDefault())
-    val date = Date.from(this)
-    return timeFormat.format(date)
-}
+fun Instant.getShortTimeText(): String = getStringOfPattern(TimeFormat.timePattern)
+
+/** Clock time only, honouring the 12/24 hour preference. */
+fun Instant.getTimeText(): String = getStringOfPattern(TimeFormat.timePattern)
+
+/** Weekday plus clock time, honouring the 12/24 hour preference. */
+fun Instant.getWeekdayTimeText(): String =
+    getStringOfPattern("EEE " + TimeFormat.timePattern)
 
 fun LocalDateTime.getStringOfPattern(pattern: String): String {
     val formatter = DateTimeFormatter.ofPattern(pattern)
@@ -65,10 +66,14 @@ fun LocalDateTime.getDateWithWeekdayText(): String {
     return getStringOfPattern("EEE dd MMM yyyy")
 }
 
-fun LocalDateTime.getShortTimeText(): String {
-    val instant = getInstant()
-    return instant.getShortTimeText()
-}
+fun LocalDateTime.getShortTimeText(): String = getStringOfPattern(TimeFormat.timePattern)
+
+/** Clock time only, honouring the 12/24 hour preference. */
+fun LocalDateTime.getTimeText(): String = getStringOfPattern(TimeFormat.timePattern)
+
+/** Weekday plus clock time, honouring the 12/24 hour preference. */
+fun LocalDateTime.getWeekdayTimeText(): String =
+    getStringOfPattern("EEE " + TimeFormat.timePattern)
 
 fun Instant.getLocalDateTime(): LocalDateTime =
     LocalDateTime.ofInstant(this, ZoneId.systemDefault())

--- a/app/src/main/java/com/isaakhanimann/journal/ui/utils/keyboard/isKeyboardOpen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/utils/keyboard/isKeyboardOpen.kt
@@ -18,27 +18,26 @@
 
 package com.isaakhanimann.journal.ui.utils.keyboard
 
-import android.graphics.Rect
-import android.view.ViewTreeObserver
-import androidx.compose.runtime.*
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
 
+/**
+ * WindowInsets.ime reads from the already-tracked IME inset state, so recomposition only
+ * happens when the keyboard's height actually changes. The previous implementation used an
+ * OnGlobalLayoutListener that fired on every layout pass in the window (including every tab
+ * switch and animation frame) and called the IPC-backed getWindowVisibleDisplayFrame() each
+ * time, which was a measurable source of main-thread jank.
+ */
 @Composable
 fun isKeyboardOpen(): State<Boolean> {
-    val keyboardState = remember { mutableStateOf(false) }
-    val view = LocalView.current
-    DisposableEffect(view) {
-        val onGlobalListener = ViewTreeObserver.OnGlobalLayoutListener {
-            val rect = Rect()
-            view.getWindowVisibleDisplayFrame(rect)
-            val screenHeight = view.rootView.height
-            val keypadHeight = screenHeight - rect.bottom
-            keyboardState.value = keypadHeight > screenHeight * 0.15
-        }
-        view.viewTreeObserver.addOnGlobalLayoutListener(onGlobalListener)
-        onDispose {
-            view.viewTreeObserver.removeOnGlobalLayoutListener(onGlobalListener)
-        }
-    }
-    return keyboardState
+    val density = LocalDensity.current
+    val imeVisible = WindowInsets.ime.getBottom(density) > 0
+    val state = remember { mutableStateOf(imeVisible) }
+    state.value = imeVisible
+    return state
 }


### PR DESCRIPTION
## What's in this PR

### Color palette
AdaptiveColor.kt had regressed to 51 entries (missing 60) after a merge.
Restored to the full 111-color set matching the 15.5 release.

### Icon picker was completely non-functional (pre-existing bug)
`getCurrentIconKey()` only treated `COMPONENT_ENABLED_STATE_ENABLED` as
"active," but the manifest's default alias starts in
`COMPONENT_ENABLED_STATE_DEFAULT` until explicitly toggled, so the picker
always showed the wrong selection and both options were effectively
no-ops. Also fixed the alias switch order (enable-before-disable, so
there's never a moment with zero enabled launcher icons) and a missing
`DONT_KILL_APP` flag that was killing the process on every switch.

### New: 12/24-hour clock setting
Toggle in Settings, defaulting to the phone's system setting. Backed by
a new `TimeFormat` singleton, threaded through ingestion times, the
timeline axis, and notifications.

### Performance
- **Journal list scroll**: missing `LazyColumn` item key, and
  `ExperienceRow` computing the full shareable-card data (substance
  lookups, dose math, interaction checks) on every recomposition instead
  of only on share-tap.
- **Tab-switch stalls**: `isKeyboardOpen()` used an
  `OnGlobalLayoutListener` firing on every layout pass, each call doing
  a synchronous Binder IPC (`getWindowVisibleDisplayFrame`). Replaced
  with `WindowInsets.ime`, which only recomposes on actual keyboard
  visibility changes.
- Moved the journal search/filter flow off the main thread with
  `flowOn(Dispatchers.Default)`.

## Testing
Verified colors match the reference build. Confirmed smooth scrolling
and tab switching via `dumpsys gfxinfo` before/after on a real
low-end device (~50% janky frames → smooth).