### PR TITLE
Hide bottom nav on nested screens; scroll-aware hide/reveal on tab roots

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/BottomBarNestedScroll.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/BottomBarNestedScroll.kt
@@ -1,0 +1,22 @@
+package com.isaakhanimann.journal.ui.main
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+
+/**
+ * Nested-scroll connection owned by [MainScreen] so the bottom bar can hide/show
+ * with tab-root content. Each tab Scaffold must attach this; a connection on
+ * [androidx.navigation.compose.NavHost] does not receive descendant LazyColumn
+ * / verticalScroll events through Navigation Compose.
+ */
+val LocalBottomBarNestedScrollConnection =
+    compositionLocalOf<NestedScrollConnection?> { null }
+
+@Composable
+fun Modifier.bottomBarNestedScroll(): Modifier {
+    val connection = LocalBottomBarNestedScrollConnection.current
+    return if (connection != null) nestedScroll(connection) else this
+}

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/BottomBarNestedScroll.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/BottomBarNestedScroll.kt
@@ -1,10 +1,13 @@
 package com.isaakhanimann.journal.ui.main
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 
 /**
  * Nested-scroll connection owned by [MainScreen] so the bottom bar can hide/show
@@ -15,8 +18,26 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 val LocalBottomBarNestedScrollConnection =
     compositionLocalOf<NestedScrollConnection?> { null }
 
+/**
+ * Remaining visible height of the overlay NavigationBar, in px.
+ * Tab lists/FABs use this as content padding so items aren't covered, while
+ * the page background fills the screen (no reserved empty slot).
+ */
+val LocalBottomBarOverlayInsetPx = staticCompositionLocalOf { 0 }
+
 @Composable
 fun Modifier.bottomBarNestedScroll(): Modifier {
     val connection = LocalBottomBarNestedScrollConnection.current
     return if (connection != null) nestedScroll(connection) else this
+}
+
+@Composable
+fun bottomBarOverlayPadding(): PaddingValues {
+    val px = LocalBottomBarOverlayInsetPx.current
+    return PaddingValues(bottom = with(LocalDensity.current) { px.toDp() })
+}
+
+@Composable
+fun bottomBarOverlayDp() = with(LocalDensity.current) {
+    LocalBottomBarOverlayInsetPx.current.toDp()
 }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -18,6 +18,9 @@
 
 package com.isaakhanimann.journal.ui.main
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -33,9 +36,16 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -56,6 +66,7 @@ import com.isaakhanimann.journal.ui.main.navigation.graphs.searchGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.settingsGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.statsGraph
 import com.isaakhanimann.journal.ui.main.navigation.routers.TabRouter
+import com.isaakhanimann.journal.ui.main.navigation.routers.isBottomBarHiddenRoute
 import com.isaakhanimann.journal.ui.utils.keyboard.isKeyboardOpen
 
 private fun parseNavIntent(intent: android.content.Intent?): Pair<String, Int>? {
@@ -99,6 +110,9 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         AppLockScreen(onUnlocked = viewModel::markUnlocked)
     } else {
         val navController = rememberNavController()
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentDestination = navBackStackEntry?.destination
+
         LaunchedEffect(pendingNav) {
             pendingNav?.let { (target, experienceId) ->
                 when (target) {
@@ -110,13 +124,48 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                 pendingNav = null
             }
         }
+
+        // Scroll-aware bottom bar: swipe up (content scrolls upward) hides it,
+        // swipe down reveals it again, animated via AnimatedVisibility.
+        var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
+        var scrollAccum by remember { mutableStateOf(0f) }
+        val scrollThreshold = with(LocalDensity.current) { 24.dp.toPx() }
+        val nestedScrollConnection = remember {
+            object : NestedScrollConnection {
+                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    if (source == NestedScrollSource.UserInput) {
+                        scrollAccum += available.y
+                        // Positive y = content scrolls upward (finger swipes up, scrolling
+                        // toward the list end): hide the bar. Negative y = swipe down: reveal it.
+                        if (scrollAccum > scrollThreshold && !barHiddenByScroll) {
+                            barHiddenByScroll = true
+                            scrollAccum = 0f
+                        } else if (scrollAccum < -scrollThreshold && barHiddenByScroll) {
+                            barHiddenByScroll = false
+                            scrollAccum = 0f
+                        }
+                    }
+                    return Offset.Zero
+                }
+            }
+        }
+        // Reset the scroll-hidden state whenever a new destination is shown.
+        LaunchedEffect(currentDestination) {
+            barHiddenByScroll = false
+        }
+
+        val isKeyboardOpenNow = isKeyboardOpen().value
+        val isBottomBarShown = !isBottomBarHiddenRoute(currentDestination?.route) &&
+            !isKeyboardOpenNow && !barHiddenByScroll
+
         Scaffold(
             bottomBar = {
-                val isShowingBottomBar = isKeyboardOpen().value.not()
-                if (isShowingBottomBar) {
+                AnimatedVisibility(
+                    visible = isBottomBarShown,
+                    enter = slideInVertically { it },
+                    exit = slideOutVertically { it }
+                ) {
                     NavigationBar {
-                        val navBackStackEntry by navController.currentBackStackEntryAsState()
-                        val currentDestination = navBackStackEntry?.destination
                         val tabs = listOf(
                             TabRouter.Statistics,
                             TabRouter.Journal,
@@ -166,6 +215,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                 navController,
                 startDestination = TabRouter.Journal.route,
                 modifier = Modifier
+                    .nestedScroll(nestedScrollConnection)
                     .padding(bottom = innerPadding.calculateBottomPadding())
             ) {
                 journalGraph(navController)

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -129,23 +129,26 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         }
 
-        // Scroll-aware bottom bar: swiping up (content scrolls upward) slides the bar
-        // out toward the bottom; swiping down slides it back in. Applied only on the
-        // top-level tab roots (the bar does not exist on nested screens at all).
+        // Scroll-aware bottom bar. Nested-scroll sign convention: consumed.y < 0
+        // when content scrolls toward the list end (finger swipe up / "scroll down
+        // to see more"). Hide then. consumed.y > 0 when scrolling back toward the
+        // top: show. 40.dp hysteresis so tiny jitter does not flip the bar.
         var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
         var scrollAccum by remember { mutableStateOf(0f) }
         val scrollThreshold = with(LocalDensity.current) { 40.dp.toPx() }
         val nestedScrollConnection = remember {
             object : NestedScrollConnection {
-                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource
+                ): Offset {
                     if (source == NestedScrollSource.UserInput) {
-                        // Positive y = content scrolls upward (finger swipes up): hide the bar.
-                        // Negative y = content scrolls downward (finger swipes down): show it.
-                        scrollAccum += available.y
-                        if (scrollAccum > scrollThreshold && !barHiddenByScroll) {
+                        scrollAccum += consumed.y
+                        if (scrollAccum < -scrollThreshold && !barHiddenByScroll) {
                             barHiddenByScroll = true
                             scrollAccum = 0f
-                        } else if (scrollAccum < -scrollThreshold && barHiddenByScroll) {
+                        } else if (scrollAccum > scrollThreshold && barHiddenByScroll) {
                             barHiddenByScroll = false
                             scrollAccum = 0f
                         }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -19,6 +19,9 @@
 package com.isaakhanimann.journal.ui.main
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
@@ -38,6 +41,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -66,7 +70,7 @@ import com.isaakhanimann.journal.ui.main.navigation.graphs.searchGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.settingsGraph
 import com.isaakhanimann.journal.ui.main.navigation.graphs.statsGraph
 import com.isaakhanimann.journal.ui.main.navigation.routers.TabRouter
-import com.isaakhanimann.journal.ui.main.navigation.routers.isBottomBarHiddenRoute
+import com.isaakhanimann.journal.ui.main.navigation.routers.isMainTabRootRoute
 import com.isaakhanimann.journal.ui.utils.keyboard.isKeyboardOpen
 
 private fun parseNavIntent(intent: android.content.Intent?): Pair<String, Int>? {
@@ -125,8 +129,9 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         }
 
-        // Scroll-aware bottom bar: swipe up (content scrolls upward) hides it,
-        // swipe down reveals it again, animated via AnimatedVisibility.
+        // Scroll-aware bottom bar: swiping up (content scrolls upward) slides the bar
+        // out toward the bottom; swiping down slides it back in. Applied only on the
+        // top-level tab roots (the bar does not exist on nested screens at all).
         var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
         var scrollAccum by remember { mutableStateOf(0f) }
         val scrollThreshold = with(LocalDensity.current) { 24.dp.toPx() }
@@ -134,9 +139,9 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             object : NestedScrollConnection {
                 override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
                     if (source == NestedScrollSource.UserInput) {
+                        // Positive y = content scrolls upward (finger swipes up): hide the bar.
+                        // Negative y = content scrolls downward (finger swipes down): show it.
                         scrollAccum += available.y
-                        // Positive y = content scrolls upward (finger swipes up, scrolling
-                        // toward the list end): hide the bar. Negative y = swipe down: reveal it.
                         if (scrollAccum > scrollThreshold && !barHiddenByScroll) {
                             barHiddenByScroll = true
                             scrollAccum = 0f
@@ -149,21 +154,25 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                 }
             }
         }
-        // Reset the scroll-hidden state whenever a new destination is shown.
+        // The bar is always shown by default whenever a destination is (re)entered.
         LaunchedEffect(currentDestination) {
             barHiddenByScroll = false
         }
 
         val isKeyboardOpenNow = isKeyboardOpen().value
-        val isBottomBarShown = !isBottomBarHiddenRoute(currentDestination?.route) &&
-            !isKeyboardOpenNow && !barHiddenByScroll
+        val isOnMainTabRoot = isMainTabRootRoute(currentDestination?.route)
+        val isBottomBarShown = isOnMainTabRoot && !isKeyboardOpenNow && !barHiddenByScroll
 
         Scaffold(
             bottomBar = {
+                // Continuous displacement: slide in/out vertically while expanding/
+                // shrinking from the bottom edge, so the bar moves as one smooth unit.
                 AnimatedVisibility(
                     visible = isBottomBarShown,
-                    enter = slideInVertically { it },
-                    exit = slideOutVertically { it }
+                    enter = slideInVertically(tween(durationMillis = 250)) { it } +
+                        expandVertically(tween(durationMillis = 250), expandFrom = Alignment.Bottom),
+                    exit = slideOutVertically(tween(durationMillis = 250)) { it } +
+                        shrinkVertically(tween(durationMillis = 250), shrinkTowards = Alignment.Bottom)
                 ) {
                     NavigationBar {
                         val tabs = listOf(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -134,7 +134,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         // top-level tab roots (the bar does not exist on nested screens at all).
         var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
         var scrollAccum by remember { mutableStateOf(0f) }
-        val scrollThreshold = with(LocalDensity.current) { 24.dp.toPx() }
+        val scrollThreshold = with(LocalDensity.current) { 40.dp.toPx() }
         val nestedScrollConnection = remember {
             object : NestedScrollConnection {
                 override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -41,9 +41,9 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +52,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -175,10 +176,35 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         }
 
-        Scaffold(
-            bottomBar = {
+        Scaffold { _ ->
+            val barHeightPx = remember { mutableIntStateOf(0) }
+            val heightOffset = bottomBarScrollBehavior.state.heightOffset
+            val visibleBarPx = if (isBottomBarShown) {
+                (barHeightPx.intValue + heightOffset.toInt()).coerceAtLeast(0)
+            } else {
+                0
+            }
+            Box(modifier = Modifier.fillMaxSize()) {
+                CompositionLocalProvider(
+                    LocalBottomBarNestedScrollConnection provides nestedScrollConnection
+                ) {
+                    NavHost(
+                        navController,
+                        startDestination = TabRouter.Journal.route,
+                        modifier = Modifier.padding(
+                            bottom = with(LocalDensity.current) { visibleBarPx.toDp() }
+                        )
+                    ) {
+                        journalGraph(navController)
+                        statsGraph(navController)
+                        searchGraph(navController)
+                        saferGraph(navController)
+                        settingsGraph(navController)
+                    }
+                }
                 AnimatedVisibility(
                     visible = isBottomBarShown,
+                    modifier = Modifier.align(Alignment.BottomCenter),
                     enter = slideInVertically(tween(durationMillis = 250)) { it } +
                         expandVertically(tween(durationMillis = 250), expandFrom = Alignment.Bottom),
                     exit = slideOutVertically(tween(durationMillis = 250)) { it } +
@@ -187,6 +213,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                     NavigationBar(
                         modifier = Modifier
                             .onSizeChanged { size ->
+                                barHeightPx.intValue = size.height
                                 bottomBarScrollBehavior.state.heightOffsetLimit =
                                     -size.height.toFloat()
                             }
@@ -239,23 +266,6 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                             )
                         }
                     }
-                }
-            }
-        ) { innerPadding ->
-            CompositionLocalProvider(
-                LocalBottomBarNestedScrollConnection provides nestedScrollConnection
-            ) {
-                NavHost(
-                    navController,
-                    startDestination = TabRouter.Journal.route,
-                    modifier = Modifier
-                        .padding(bottom = innerPadding.calculateBottomPadding())
-                ) {
-                    journalGraph(navController)
-                    statsGraph(navController)
-                    searchGraph(navController)
-                    saferGraph(navController)
-                    settingsGraph(navController)
                 }
             }
         }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomAppBarDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -44,12 +46,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.offset
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -78,6 +79,7 @@ private fun parseNavIntent(intent: android.content.Intent?): Pair<String, Int>? 
     return target to intent.getIntExtra(EXTRA_EXPERIENCE_ID, -1)
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
     val selectedLanguageKey by viewModel.selectedLanguageFlow.collectAsState()
@@ -129,48 +131,23 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         }
 
-        // Scroll-aware bottom bar. Nested-scroll sign convention: consumed.y < 0
-        // when content scrolls toward the list end (finger swipe up / "scroll down
-        // to see more"). Hide then. consumed.y > 0 when scrolling back toward the
-        // top: show. 12.dp hysteresis (about 1/3 of 40.dp) so a short swipe hides
-        // the bar without flipping on tiny jitter.
-        var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
-        var scrollAccum by remember { mutableStateOf(0f) }
-        val scrollThreshold = with(LocalDensity.current) { 12.dp.toPx() }
-        val nestedScrollConnection = remember {
-            object : NestedScrollConnection {
-                override fun onPostScroll(
-                    consumed: Offset,
-                    available: Offset,
-                    source: NestedScrollSource
-                ): Offset {
-                    if (source == NestedScrollSource.UserInput) {
-                        scrollAccum += consumed.y
-                        if (scrollAccum < -scrollThreshold && !barHiddenByScroll) {
-                            barHiddenByScroll = true
-                            scrollAccum = 0f
-                        } else if (scrollAccum > scrollThreshold && barHiddenByScroll) {
-                            barHiddenByScroll = false
-                            scrollAccum = 0f
-                        }
-                    }
-                    return Offset.Zero
-                }
-            }
-        }
-        // The bar is always shown by default whenever a destination is (re)entered.
-        LaunchedEffect(currentDestination) {
-            barHiddenByScroll = false
-        }
-
         val isKeyboardOpenNow = isKeyboardOpen().value
         val isOnMainTabRoot = isMainTabRootRoute(currentDestination?.route)
-        val isBottomBarShown = isOnMainTabRoot && !isKeyboardOpenNow && !barHiddenByScroll
+        val isBottomBarShown = isOnMainTabRoot && !isKeyboardOpenNow
+
+        // Material3 official hide-on-scroll: BottomAppBarDefaults.exitAlwaysScrollBehavior.
+        // NavigationBar has no scrollBehavior param; drive translationY from heightOffset.
+        val bottomBarScrollBehavior = BottomAppBarDefaults.exitAlwaysScrollBehavior(
+            canScroll = { isOnMainTabRoot && !isKeyboardOpenNow }
+        )
+        LaunchedEffect(isOnMainTabRoot, isKeyboardOpenNow) {
+            if (!isOnMainTabRoot || isKeyboardOpenNow) {
+                bottomBarScrollBehavior.state.heightOffset = 0f
+            }
+        }
 
         Scaffold(
             bottomBar = {
-                // Continuous displacement: slide in/out vertically while expanding/
-                // shrinking from the bottom edge, so the bar moves as one smooth unit.
                 AnimatedVisibility(
                     visible = isBottomBarShown,
                     enter = slideInVertically(tween(durationMillis = 250)) { it } +
@@ -178,7 +155,14 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                     exit = slideOutVertically(tween(durationMillis = 250)) { it } +
                         shrinkVertically(tween(durationMillis = 250), shrinkTowards = Alignment.Bottom)
                 ) {
-                    NavigationBar {
+                    NavigationBar(
+                        modifier = Modifier.offset {
+                            IntOffset(
+                                x = 0,
+                                y = -bottomBarScrollBehavior.state.heightOffset.toInt()
+                            )
+                        }
+                    ) {
                         val tabs = listOf(
                             TabRouter.Statistics,
                             TabRouter.Journal,
@@ -225,7 +209,8 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         ) { innerPadding ->
             CompositionLocalProvider(
-                LocalBottomBarNestedScrollConnection provides nestedScrollConnection
+                LocalBottomBarNestedScrollConnection provides
+                    bottomBarScrollBehavior.nestedScrollConnection
             ) {
                 NavHost(
                     navController,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -132,10 +132,11 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         // Scroll-aware bottom bar. Nested-scroll sign convention: consumed.y < 0
         // when content scrolls toward the list end (finger swipe up / "scroll down
         // to see more"). Hide then. consumed.y > 0 when scrolling back toward the
-        // top: show. 40.dp hysteresis so tiny jitter does not flip the bar.
+        // top: show. 12.dp hysteresis (about 1/3 of 40.dp) so a short swipe hides
+        // the bar without flipping on tiny jitter.
         var barHiddenByScroll by rememberSaveable { mutableStateOf(false) }
         var scrollAccum by remember { mutableStateOf(0f) }
-        val scrollThreshold = with(LocalDensity.current) { 40.dp.toPx() }
+        val scrollThreshold = with(LocalDensity.current) { 12.dp.toPx() }
         val nestedScrollConnection = remember {
             object : NestedScrollConnection {
                 override fun onPostScroll(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -27,13 +27,11 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -52,7 +50,6 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
@@ -176,7 +173,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         }
 
-        Scaffold { _ ->
+        Box(modifier = Modifier.fillMaxSize()) {
             val barHeightPx = remember { mutableIntStateOf(0) }
             val heightOffset = bottomBarScrollBehavior.state.heightOffset
             val visibleBarPx = if (isBottomBarShown) {
@@ -184,87 +181,84 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             } else {
                 0
             }
-            Box(modifier = Modifier.fillMaxSize()) {
-                CompositionLocalProvider(
-                    LocalBottomBarNestedScrollConnection provides nestedScrollConnection
+            CompositionLocalProvider(
+                LocalBottomBarNestedScrollConnection provides nestedScrollConnection,
+                LocalBottomBarOverlayInsetPx provides visibleBarPx
+            ) {
+                NavHost(
+                    navController,
+                    startDestination = TabRouter.Journal.route,
+                    modifier = Modifier.fillMaxSize()
                 ) {
-                    NavHost(
-                        navController,
-                        startDestination = TabRouter.Journal.route,
-                        modifier = Modifier.padding(
-                            bottom = with(LocalDensity.current) { visibleBarPx.toDp() }
-                        )
-                    ) {
-                        journalGraph(navController)
-                        statsGraph(navController)
-                        searchGraph(navController)
-                        saferGraph(navController)
-                        settingsGraph(navController)
-                    }
+                    journalGraph(navController)
+                    statsGraph(navController)
+                    searchGraph(navController)
+                    saferGraph(navController)
+                    settingsGraph(navController)
                 }
-                AnimatedVisibility(
-                    visible = isBottomBarShown,
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    enter = slideInVertically(tween(durationMillis = 250)) { it } +
-                        expandVertically(tween(durationMillis = 250), expandFrom = Alignment.Bottom),
-                    exit = slideOutVertically(tween(durationMillis = 250)) { it } +
-                        shrinkVertically(tween(durationMillis = 250), shrinkTowards = Alignment.Bottom)
-                ) {
-                    NavigationBar(
-                        modifier = Modifier
-                            .onSizeChanged { size ->
-                                barHeightPx.intValue = size.height
-                                bottomBarScrollBehavior.state.heightOffsetLimit =
-                                    -size.height.toFloat()
-                            }
-                            .offset {
-                                IntOffset(
-                                    x = 0,
-                                    y = -bottomBarScrollBehavior.state.heightOffset.toInt()
-                                )
-                            }
-                    ) {
-                        val tabs = listOf(
-                            TabRouter.Statistics,
-                            TabRouter.Journal,
-                            TabRouter.Substances,
-                            TabRouter.SaferUse,
-                            TabRouter.Settings
-                        )
-                        tabs.forEach { tab ->
-                            val isSelected =
-                                currentDestination?.hierarchy?.any { it.route == tab.route } == true
-                            NavigationBarItem(
-                                icon = {
-                                    if (isSelected) {
-                                        Icon(tab.iconSelected, contentDescription = null)
-                                    } else {
-                                        Icon(tab.icon, contentDescription = null)
-                                    }
-                                },
-                                label = { Text(i18n(tab.labelKey)) },
-                                selected = isSelected,
-                                onClick = {
-                                    if (isSelected) {
-                                        val isAlreadyOnTopOfTab = tabs.any {
-                                            it.childRoute ==
-                                                currentDestination.route
-                                        }
-                                        if (!isAlreadyOnTopOfTab) {
-                                            navController.popBackStack()
-                                        }
-                                    } else {
-                                        navController.navigate(tab.route) {
-                                            popUpTo(navController.graph.findStartDestination().id) {
-                                                saveState = true
-                                            }
-                                            launchSingleTop = true
-                                            restoreState = true
-                                        }
-                                    }
-                                }
+            }
+            AnimatedVisibility(
+                visible = isBottomBarShown,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                enter = slideInVertically(tween(durationMillis = 250)) { it } +
+                    expandVertically(tween(durationMillis = 250), expandFrom = Alignment.Bottom),
+                exit = slideOutVertically(tween(durationMillis = 250)) { it } +
+                    shrinkVertically(tween(durationMillis = 250), shrinkTowards = Alignment.Bottom)
+            ) {
+                NavigationBar(
+                    modifier = Modifier
+                        .onSizeChanged { size ->
+                            barHeightPx.intValue = size.height
+                            bottomBarScrollBehavior.state.heightOffsetLimit =
+                                -size.height.toFloat()
+                        }
+                        .offset {
+                            IntOffset(
+                                x = 0,
+                                y = -bottomBarScrollBehavior.state.heightOffset.toInt()
                             )
                         }
+                ) {
+                    val tabs = listOf(
+                        TabRouter.Statistics,
+                        TabRouter.Journal,
+                        TabRouter.Substances,
+                        TabRouter.SaferUse,
+                        TabRouter.Settings
+                    )
+                    tabs.forEach { tab ->
+                        val isSelected =
+                            currentDestination?.hierarchy?.any { it.route == tab.route } == true
+                        NavigationBarItem(
+                            icon = {
+                                if (isSelected) {
+                                    Icon(tab.iconSelected, contentDescription = null)
+                                } else {
+                                    Icon(tab.icon, contentDescription = null)
+                                }
+                            },
+                            label = { Text(i18n(tab.labelKey)) },
+                            selected = isSelected,
+                            onClick = {
+                                if (isSelected) {
+                                    val isAlreadyOnTopOfTab = tabs.any {
+                                        it.childRoute ==
+                                            currentDestination.route
+                                    }
+                                    if (!isAlreadyOnTopOfTab) {
+                                        navController.popBackStack()
+                                    }
+                                } else {
+                                    navController.navigate(tab.route) {
+                                        popUpTo(navController.graph.findStartDestination().id) {
+                                            saveState = true
+                                        }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                }
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -46,7 +47,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
@@ -223,18 +223,21 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                 }
             }
         ) { innerPadding ->
-            NavHost(
-                navController,
-                startDestination = TabRouter.Journal.route,
-                modifier = Modifier
-                    .nestedScroll(nestedScrollConnection)
-                    .padding(bottom = innerPadding.calculateBottomPadding())
+            CompositionLocalProvider(
+                LocalBottomBarNestedScrollConnection provides nestedScrollConnection
             ) {
-                journalGraph(navController)
-                statsGraph(navController)
-                searchGraph(navController)
-                saferGraph(navController)
-                settingsGraph(navController)
+                NavHost(
+                    navController,
+                    startDestination = TabRouter.Journal.route,
+                    modifier = Modifier
+                        .padding(bottom = innerPadding.calculateBottomPadding())
+                ) {
+                    journalGraph(navController)
+                    statsGraph(navController)
+                    searchGraph(navController)
+                    saferGraph(navController)
+                    settingsGraph(navController)
+                }
             }
         }
     }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -46,11 +47,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.offset
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -135,11 +137,38 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         val isOnMainTabRoot = isMainTabRootRoute(currentDestination?.route)
         val isBottomBarShown = isOnMainTabRoot && !isKeyboardOpenNow
 
-        // Material3 official hide-on-scroll: BottomAppBarDefaults.exitAlwaysScrollBehavior.
-        // NavigationBar has no scrollBehavior param; drive translationY from heightOffset.
+        // Official Material3 hide-on-scroll connection, plus onPreScroll so an
+        // upward swipe at the list top (consumed.y == 0) still reveals the bar.
         val bottomBarScrollBehavior = BottomAppBarDefaults.exitAlwaysScrollBehavior(
             canScroll = { isOnMainTabRoot && !isKeyboardOpenNow }
         )
+        val nestedScrollConnection = remember(bottomBarScrollBehavior) {
+            val official = bottomBarScrollBehavior.nestedScrollConnection
+            object : NestedScrollConnection {
+                override fun onPreScroll(
+                    available: Offset,
+                    source: NestedScrollSource
+                ): Offset {
+                    if (available.y > 0f &&
+                        bottomBarScrollBehavior.state.heightOffset < 0f
+                    ) {
+                        val state = bottomBarScrollBehavior.state
+                        val next = (state.heightOffset + available.y)
+                            .coerceIn(state.heightOffsetLimit, 0f)
+                        val consumedY = next - state.heightOffset
+                        state.heightOffset = next
+                        return Offset(0f, consumedY)
+                    }
+                    return Offset.Zero
+                }
+
+                override fun onPostScroll(
+                    consumed: Offset,
+                    available: Offset,
+                    source: NestedScrollSource
+                ): Offset = official.onPostScroll(consumed, available, source)
+            }
+        }
         LaunchedEffect(isOnMainTabRoot, isKeyboardOpenNow) {
             if (!isOnMainTabRoot || isKeyboardOpenNow) {
                 bottomBarScrollBehavior.state.heightOffset = 0f
@@ -156,12 +185,17 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                         shrinkVertically(tween(durationMillis = 250), shrinkTowards = Alignment.Bottom)
                 ) {
                     NavigationBar(
-                        modifier = Modifier.offset {
-                            IntOffset(
-                                x = 0,
-                                y = -bottomBarScrollBehavior.state.heightOffset.toInt()
-                            )
-                        }
+                        modifier = Modifier
+                            .onSizeChanged { size ->
+                                bottomBarScrollBehavior.state.heightOffsetLimit =
+                                    -size.height.toFloat()
+                            }
+                            .offset {
+                                IntOffset(
+                                    x = 0,
+                                    y = -bottomBarScrollBehavior.state.heightOffset.toInt()
+                                )
+                            }
                     ) {
                         val tabs = listOf(
                             TabRouter.Statistics,
@@ -209,8 +243,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
             }
         ) { innerPadding ->
             CompositionLocalProvider(
-                LocalBottomBarNestedScrollConnection provides
-                    bottomBarScrollBehavior.nestedScrollConnection
+                LocalBottomBarNestedScrollConnection provides nestedScrollConnection
             ) {
                 NavHost(
                     navController,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
@@ -72,6 +72,44 @@ private const val ROUTE_START_URL = "url/"
 private const val ROUTE_START_JOURNAL_TAB_URL = "journalTabUrl/"
 private const val ROUTE_START_SAFER_TAB_URL = "saferTabUrl/"
 
+// Argument-route patterns (with a trailing "/") on which the bottom navigation
+// bar must never appear. These are the focused add/edit form flows.
+private val bottomBarHiddenRoutePrefixes = listOf(
+    ROUTE_START_EDIT_EXPERIENCE,
+    ROUTE_START_INGESTIONS,
+    ROUTE_START_EDIT_RATING,
+    ROUTE_START_EDIT_TIMED_NOTE,
+    ROUTE_START_EDIT_CUSTOM,
+    ROUTE_START_EDIT_CUSTOM_UNIT,
+    ROUTE_START_ADD_RATING,
+    ROUTE_START_ADD_TIMED_NOTE,
+    ROUTE_START_QUICK_TIMED_NOTE,
+    ROUTE_START_CHECK_INTERACTIONS,
+    ROUTE_START_CHECK_SAFER_USE,
+    ROUTE_START_CHOOSE_DOSE_CUSTOM_UNIT,
+    ROUTE_START_CHOOSE_ROUTE_OF_ADD_INGESTION,
+    ROUTE_START_CHOOSE_ROUTE_CUSTOM,
+    ROUTE_START_CHOOSE_DOSE_CUSTOM,
+    ROUTE_START_CHOOSE_DOSE,
+    ROUTE_START_CHOOSE_TIME,
+    ROUTE_START_OF_ADD_CUSTOM_UNIT,
+    ROUTE_START_FINISH_ADD_CUSTOM_UNIT
+)
+
+// No-argument add-flow routes (exact matches) on which the bar must never appear.
+private val bottomBarHiddenRouteExact = setOf(
+    NoArgumentRouter.AddCustomRouter.route,
+    NoArgumentRouter.AddIngestionSearchRouter.route,
+    NoArgumentRouter.AddIngestionRouter.route,
+    NoArgumentRouter.AddCustomUnitsSearchSubstanceRouter.route,
+    NoArgumentRouter.AddCustomUnitsRouter.route
+)
+
+/** True when the bottom navigation bar should be hidden on the given destination route. */
+fun isBottomBarHiddenRoute(route: String?): Boolean = route != null &&
+    (bottomBarHiddenRouteExact.contains(route) ||
+        bottomBarHiddenRoutePrefixes.any { route.startsWith(it) })
+
 sealed class ArgumentRouter(val route: String, val args: List<NamedNavArgument>) {
     object ExperienceRouter : ArgumentRouter(
         route = "$ROUTE_START_EXPERIENCES{$EXPERIENCE_ID_KEY}",

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/navigation/routers/ArgumentRouter.kt
@@ -72,43 +72,22 @@ private const val ROUTE_START_URL = "url/"
 private const val ROUTE_START_JOURNAL_TAB_URL = "journalTabUrl/"
 private const val ROUTE_START_SAFER_TAB_URL = "saferTabUrl/"
 
-// Argument-route patterns (with a trailing "/") on which the bottom navigation
-// bar must never appear. These are the focused add/edit form flows.
-private val bottomBarHiddenRoutePrefixes = listOf(
-    ROUTE_START_EDIT_EXPERIENCE,
-    ROUTE_START_INGESTIONS,
-    ROUTE_START_EDIT_RATING,
-    ROUTE_START_EDIT_TIMED_NOTE,
-    ROUTE_START_EDIT_CUSTOM,
-    ROUTE_START_EDIT_CUSTOM_UNIT,
-    ROUTE_START_ADD_RATING,
-    ROUTE_START_ADD_TIMED_NOTE,
-    ROUTE_START_QUICK_TIMED_NOTE,
-    ROUTE_START_CHECK_INTERACTIONS,
-    ROUTE_START_CHECK_SAFER_USE,
-    ROUTE_START_CHOOSE_DOSE_CUSTOM_UNIT,
-    ROUTE_START_CHOOSE_ROUTE_OF_ADD_INGESTION,
-    ROUTE_START_CHOOSE_ROUTE_CUSTOM,
-    ROUTE_START_CHOOSE_DOSE_CUSTOM,
-    ROUTE_START_CHOOSE_DOSE,
-    ROUTE_START_CHOOSE_TIME,
-    ROUTE_START_OF_ADD_CUSTOM_UNIT,
-    ROUTE_START_FINISH_ADD_CUSTOM_UNIT
+// The root route of each top-level tab. The bottom navigation bar belongs
+// only to these first-level destinations; every nested/detail screen hides it.
+private val mainTabRootRoutes = setOf(
+    NoArgumentRouter.JournalRouter.route,
+    NoArgumentRouter.StatsRouter.route,
+    NoArgumentRouter.SubstancesRouter.route,
+    NoArgumentRouter.SaferRouter.route,
+    NoArgumentRouter.SettingsRouter.route
 )
 
-// No-argument add-flow routes (exact matches) on which the bar must never appear.
-private val bottomBarHiddenRouteExact = setOf(
-    NoArgumentRouter.AddCustomRouter.route,
-    NoArgumentRouter.AddIngestionSearchRouter.route,
-    NoArgumentRouter.AddIngestionRouter.route,
-    NoArgumentRouter.AddCustomUnitsSearchSubstanceRouter.route,
-    NoArgumentRouter.AddCustomUnitsRouter.route
-)
-
-/** True when the bottom navigation bar should be hidden on the given destination route. */
-fun isBottomBarHiddenRoute(route: String?): Boolean = route != null &&
-    (bottomBarHiddenRouteExact.contains(route) ||
-        bottomBarHiddenRoutePrefixes.any { route.startsWith(it) })
+/**
+ * True when the given destination route is the root of a top-level tab.
+ * The bottom navigation bar is shown only on these routes.
+ */
+fun isMainTabRootRoute(route: String?): Boolean = route != null &&
+    mainTabRootRoutes.contains(route)
 
 sealed class ArgumentRouter(val route: String, val args: List<NamedNavArgument>) {
     object ExperienceRouter : ArgumentRouter(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -75,6 +76,8 @@ import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepositor
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.journal.components.ExperienceRow
 import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayDp
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayPadding
 import com.isaakhanimann.journal.ui.tabs.stats.EmptyScreenDisclaimer
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import kotlinx.coroutines.launch
@@ -159,6 +162,7 @@ fun JournalScreen(
         ?.experience?.id
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("journal")) },
@@ -231,6 +235,7 @@ fun JournalScreen(
         floatingActionButton = {
             if (!isSearchEnabled) {
                 ExtendedFloatingActionButton(
+                    modifier = Modifier.padding(bottom = bottomBarOverlayDp()),
                     onClick = navigateToAddIngestion,
                     icon = {
                         Icon(
@@ -332,7 +337,8 @@ fun JournalScreen(
                 Box(contentAlignment = Alignment.TopEnd) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        state = listState
+                        state = listState,
+                        contentPadding = bottomBarOverlayPadding()
                     ) {
                         if (experiences.isNotEmpty()) {
                             item {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -74,6 +74,7 @@ import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithI
 import com.isaakhanimann.journal.data.substances.repositories.SubstanceRepository
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.tabs.journal.components.ExperienceRow
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.ui.tabs.stats.EmptyScreenDisclaimer
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import kotlinx.coroutines.launch
@@ -157,6 +158,7 @@ fun JournalScreen(
         .firstOrNull { it.ingestionsWithCompanions.isNotEmpty() }
         ?.experience?.id
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("journal")) },

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.ui.tabs.search.substance.SectionWithTitle
 import com.isaakhanimann.journal.ui.tabs.search.substance.VerticalSpace
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
@@ -81,6 +82,7 @@ fun SaferUseScreen(
     navigateToReagentTestingScreen: () -> Unit
 ) {
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("safer_use_title")) }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
@@ -20,6 +20,7 @@ package com.isaakhanimann.journal.ui.tabs.safer
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -49,6 +50,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayDp
 import com.isaakhanimann.journal.ui.tabs.search.substance.SectionWithTitle
 import com.isaakhanimann.journal.ui.tabs.search.substance.VerticalSpace
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
@@ -83,6 +85,7 @@ fun SaferUseScreen(
 ) {
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("safer_use_title")) }
@@ -93,6 +96,7 @@ fun SaferUseScreen(
             Modifier
                 .verticalScroll(rememberScrollState())
                 .padding(padding)
+                .padding(bottom = bottomBarOverlayDp())
         ) {
             SectionWithTitle(title = i18n("safer_research_title")) {
                 SaferText(text = i18n("safer_research_body"))

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/SearchScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/SearchScreen.kt
@@ -21,6 +21,7 @@ package com.isaakhanimann.journal.ui.tabs.search
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -54,8 +55,10 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.isaakhanimann.journal.localization.i18n
-import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.localization.i18nOrDefault
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayDp
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayPadding
 import com.isaakhanimann.journal.ui.tabs.search.substancerow.SubstanceRow
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.categoryNameKey
@@ -72,9 +75,13 @@ fun SearchScreen(
 
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         floatingActionButton = {
             if (!isFocused) {
-                FloatingActionButton(onClick = { focusRequester.requestFocus() }) {
+                FloatingActionButton(
+                    modifier = Modifier.padding(bottom = bottomBarOverlayDp()),
+                    onClick = { focusRequester.requestFocus() }
+                ) {
                     Icon(Icons.Default.Keyboard, contentDescription = i18n("search_keyboard"))
                 }
             }
@@ -124,7 +131,7 @@ fun SearchScreen(
                     navigateToAddCustomSubstanceScreen = navigateToAddCustomSubstanceScreen
                 )
             } else {
-                LazyColumn {
+                LazyColumn(contentPadding = bottomBarOverlayPadding()) {
                     items(filteredCustomSubstances) { customSubstance ->
                         SubstanceRow(
                             substanceModel = SubstanceModel(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/SearchScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/search/SearchScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substancerow.SubstanceRow
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
@@ -70,6 +71,7 @@ fun SearchScreen(
     var isFocused by remember { mutableStateOf(false) }
 
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         floatingActionButton = {
             if (!isFocused) {
                 FloatingActionButton(onClick = { focusRequester.requestFocus() }) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -95,9 +95,10 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.isaakhanimann.journal.data.achievement.AchievementLogoButton
 import com.isaakhanimann.journal.localization.I18n
-import com.isaakhanimann.journal.ui.utils.TimeFormat
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.utils.TimeFormat
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardWithTitle
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
 import java.time.Instant
@@ -201,6 +202,7 @@ fun SettingsScreen(
     saveUse24HourClock: (Boolean) -> Unit = {},
 ) {
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("settings")) }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -99,6 +99,7 @@ import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.utils.TimeFormat
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardWithTitle
 import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayDp
 import com.isaakhanimann.journal.ui.theme.horizontalPadding
 import com.isaakhanimann.journal.ui.utils.getStringOfPattern
 import java.time.Instant
@@ -203,6 +204,7 @@ fun SettingsScreen(
 ) {
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
                 title = { Text(i18n("settings")) }
@@ -214,6 +216,7 @@ fun SettingsScreen(
             modifier = Modifier
                 .padding(padding)
                 .padding(horizontal = horizontalPadding)
+                .padding(bottom = bottomBarOverlayDp())
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
         ) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsAnalysisScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsAnalysisScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -101,6 +102,7 @@ import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
 import com.isaakhanimann.journal.data.substances.classes.roa.DoseClass
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayPadding
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.time.DatePickerButton
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardWithTitle
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
@@ -182,6 +184,7 @@ fun StatsAnalysisScreenContent(
 ) {
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             Column(
                 modifier = Modifier
@@ -389,7 +392,8 @@ fun StatsAnalysisScreenContent(
             LazyColumn(
                 modifier = Modifier
                     .padding(padding)
-                    .fillMaxSize()
+                    .fillMaxSize(),
+                contentPadding = bottomBarOverlayPadding()
             ) {
                 item {
                     var filtersExpanded by rememberSaveable { mutableStateOf(true) }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsAnalysisScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsAnalysisScreen.kt
@@ -100,6 +100,7 @@ import coil.compose.AsyncImage
 import com.isaakhanimann.journal.data.room.experiences.entities.AdaptiveColor
 import com.isaakhanimann.journal.data.substances.classes.roa.DoseClass
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.ui.tabs.journal.addingestion.time.DatePickerButton
 import com.isaakhanimann.journal.ui.tabs.journal.experience.components.CardWithTitle
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
@@ -180,6 +181,7 @@ fun StatsAnalysisScreenContent(
     onSelectSection: (StatsSection) -> Unit = {}
 ) {
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         topBar = {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -82,6 +83,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.isaakhanimann.journal.localization.i18n
 import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
+import com.isaakhanimann.journal.ui.main.bottomBarOverlayPadding
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.tabs.settings.AvatarUtil
@@ -161,6 +163,7 @@ fun StatsScreen(
 ) {
     Scaffold(
         modifier = Modifier.bottomBarNestedScroll(),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             Column(
                 modifier = Modifier
@@ -306,7 +309,10 @@ fun StatsScreen(
                             startDateText = statsModel.startDateText
                         )
                         HorizontalDivider()
-                        LazyColumn(modifier = Modifier.weight(1f)) {
+                        LazyColumn(
+                            modifier = Modifier.weight(1f),
+                            contentPadding = bottomBarOverlayPadding()
+                        ) {
                             items(statsModel.statItems) { subStat ->
                                 Column {
                                     Row(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.isaakhanimann.journal.localization.i18n
+import com.isaakhanimann.journal.ui.main.bottomBarNestedScroll
 import com.isaakhanimann.journal.localization.i18nOrDefault
 import com.isaakhanimann.journal.ui.tabs.search.substance.roa.toReadableString
 import com.isaakhanimann.journal.ui.tabs.settings.AvatarUtil
@@ -159,6 +160,7 @@ fun StatsScreen(
     onSelectSection: (StatsSection) -> Unit = {}
 ) {
     Scaffold(
+        modifier = Modifier.bottomBarNestedScroll(),
         topBar = {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/stats/StatsScreen.kt
@@ -270,7 +270,7 @@ fun StatsScreen(
                 description = i18n("stats_empty_description")
             )
         } else {
-            Column(modifier = Modifier.padding(padding)) {
+            Column(modifier = Modifier.padding(padding).fillMaxSize()) {
                 SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                     TimePickerOption.entries.forEachIndexed { index, option ->
                         SegmentedButton(
@@ -284,7 +284,7 @@ fun StatsScreen(
                 }
                 if (statsModel.statItems.isNotEmpty()) {
                     val isDarkTheme = isSystemInDarkTheme()
-                    Column {
+                    Column(modifier = Modifier.weight(1f)) {
                         Text(
                             text = i18n(
                                 "stats_experiences_since",
@@ -306,7 +306,7 @@ fun StatsScreen(
                             startDateText = statsModel.startDateText
                         )
                         HorizontalDivider()
-                        LazyColumn {
+                        LazyColumn(modifier = Modifier.weight(1f)) {
                             items(statsModel.statItems) { subStat ->
                                 Column {
                                     Row(


### PR DESCRIPTION
## Summary
The bottom navigation bar now belongs only to the five top-level tab roots (Journal, Statistics, Substances, Safer Use,
Settings). Nested / add / edit screens no longer show it.

On those tab roots the bar is scroll-aware:
- swipe up (content moves toward the top of the screen) hides it
- swipe down reveals it
- the soft keyboard still hides it

When the bar hides, tab content fills the freed space. Lists and FABs keep a matching `contentPadding` so the last
items are not covered.

## Behavior
- **Whitelist, not blacklist.** `isMainTabRootRoute` decides visibility. Detail screens never get a bottom bar.
- **Hide-on-scroll.** Material3 `BottomAppBarDefaults.exitAlwaysScrollBehavior()` drives `heightOffset`. A thin
`onPreScroll` wrapper restores the bar at the list top, where official `onPostScroll(consumed)` sees `consumed.y == 0`.
- **No reserved hole.** The bar overlays content. Tab-root Scaffolds zero `contentWindowInsets` at the bottom.
Remaining visible bar height is provided as `LocalBottomBarOverlayInsetPx` for list/FAB padding.
- Nested-scroll is attached on each tab-root Scaffold (a connection on `NavHost` never receives descendant `LazyColumn`
/ `verticalScroll` events).

## Files
- `MainScreen.kt` — overlay bar, official scroll behavior, tab-root gating
- `BottomBarNestedScroll.kt` — CompositionLocal connection + overlay inset
- `ArgumentRouter.kt` — `isMainTabRootRoute`
- Tab roots (`JournalScreen`, `SearchScreen`, `StatsScreen`, `StatsAnalysisScreen`, `SaferUseScreen`, `SettingsScreen`)
— nested-scroll + overlay padding

## Test plan
- [ ] On each of the 5 tab roots, swipe up hides the bar and content fills the bottom; swipe down brings the bar back
- [ ] Stats overview: hide the bar, then swipe up at the list top — bar returns
- [ ] Open an experience / substance / add-ingestion / edit screen — no bottom bar
- [ ] Keyboard open on a tab root — bar hidden; dismiss keyboard — bar returns if still on a tab root
- [ ] Journal / Search FABs stay above the bar when it is visible, and drop with it when hidden