### PR TITLE
ci(release): build and attach a signed .aab for Google Play

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -109,40 +109,47 @@ jobs:
       - name: Grant Gradle execute permission
         run: chmod +x ./gradlew
 
-      - name: Build release APK (main repo)
+      - name: Build release APK & AAB (main repo)
         if: github.repository == 'LoliLin/journal-android-multilingual'
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew assembleRelease --stacktrace
+        run: ./gradlew assembleRelease bundleRelease --stacktrace
 
 
       - name: Build debug APK (forks)
         if: github.repository != 'LoliLin/journal-android-multilingual'
         run: ./gradlew assembleDebug --stacktrace
 
-      - name: Prepare Artifacts and Rename APK
+      - name: Prepare Artifacts and Rename APK & AAB
         run: |
           mkdir -p downloads
           V_NAME="${{ github.event.inputs.version_name }}"
-          
+
           if [ "${{ github.repository }}" = "LoliLin/journal-android-multilingual" ]; then
+            # APK: collect per-ABI (or universal) release builds
             find app/build/outputs/apk/release/ -name "*.apk" -print0 | while IFS= read -r -d '' apk; do
-              # 从文件名提取 ABI 标识，如 app-arm64-v8a-release.apk → arm64-v8a
               base=$(basename "$apk" .apk)
-              # 移除 "app-" 前缀和 "-release" 后缀，剩下的就是 ABI 或 "universal"
               abi=${base#app-}
               abi=${abi%-release}
-              # 特殊情况：如果没有 ABI（只有一个 app-release.apk），则直接用 universal
               if [ -z "$abi" ] || [ "$abi" = "release" ]; then
                 abi="universal"
               fi
               cp "$apk" "downloads/journal-android-multilingual-${V_NAME}-${abi}.apk"
             done
+
+            # AAB: signed bundle for Google Play upload
+            AAB_PATH="app/build/outputs/bundle/release/app-release.aab"
+            if [ -f "$AAB_PATH" ]; then
+              cp "$AAB_PATH" "downloads/journal-android-multilingual-${V_NAME}.aab"
+              echo "AAB copied: downloads/journal-android-multilingual-${V_NAME}.aab"
+            else
+              echo "Warning: AAB file not found at $AAB_PATH"
+            fi
           else
-            # Fork 仓库：只处理 debug APK（通常只有一个）
+            # Fork repositories: debug APK only
             find app/build/outputs/apk/debug/ -name "*.apk" -print0 | while IFS= read -r -d '' apk; do
               cp "$apk" "downloads/journal-android-multilingual-${V_NAME}-debug.apk"
             done


### PR DESCRIPTION
Run bundleRelease alongside assembleRelease and copy the signed app-release.aab into downloads/ as
journal-android-multilingual-<version>.aab next to the APKs.