### PR TITLE
ci(release): gate abi splits behind ENABLE_SPLITS env

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Build release APK & AAB (main repo)
         if: github.repository == 'LoliLin/journal-android-multilingual'
         env:
+          ENABLE_SPLITS: "true"
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,9 +76,11 @@ android {
 
     splits {
         abi {
-            enable false
-            reset()  
-            include "armeabi-v7a", "arm64-v8a", "x86", "x86_64" 
+            // Per-ABI APKs only when the CI sets ENABLE_SPLITS=true; local and
+            // debug builds stay split-free so assembleDebug produces one APK.
+            enable System.getenv("ENABLE_SPLITS") == "true"
+            reset()
+            include "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
             universalApk true
         }
     }


### PR DESCRIPTION
splits.abi.enable now reads ENABLE_SPLITS so per-ABI APKs are only built when CI opts in (release workflow sets ENABLE_SPLITS=true); local builds keep producing a single APK. The release workflow also bundles the AAB in the same invocation.