### PR TITLE
Material 3 scroll behaviors for top & bottom bars

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/journal/JournalScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -65,6 +66,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -160,11 +162,15 @@ fun JournalScreen(
     val latestExperienceId = experiences
         .firstOrNull { it.ingestionsWithCompanions.isNotEmpty() }
         ?.experience?.id
+    val topBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
-        modifier = Modifier.bottomBarNestedScroll(),
+        modifier = Modifier
+            .bottomBarNestedScroll()
+            .nestedScroll(topBarScrollBehavior.nestedScrollConnection),
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
+                scrollBehavior = topBarScrollBehavior,
                 title = { Text(i18n("journal")) },
                 actions = {
                     IconToggleButton(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/safer/SaferUseScreen.kt
@@ -42,8 +42,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -83,11 +85,15 @@ fun SaferUseScreen(
     navigateToURL: (url: String) -> Unit,
     navigateToReagentTestingScreen: () -> Unit
 ) {
+    val topBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
-        modifier = Modifier.bottomBarNestedScroll(),
+        modifier = Modifier
+            .bottomBarNestedScroll()
+            .nestedScroll(topBarScrollBehavior.nestedScrollConnection),
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
+                scrollBehavior = topBarScrollBehavior,
                 title = { Text(i18n("safer_use_title")) }
             )
         }

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -78,6 +79,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -157,11 +159,15 @@ fun SettingsScreen(
     achievements: List<String> = emptyList(),
     saveOwnerUserName: (String?) -> Unit,
 ) {
+    val topBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     Scaffold(
-        modifier = Modifier.bottomBarNestedScroll(),
+        modifier = Modifier
+            .bottomBarNestedScroll()
+            .nestedScroll(topBarScrollBehavior.nestedScrollConnection),
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
             TopAppBar(
+                scrollBehavior = topBarScrollBehavior,
                 title = { Text(i18n("settings")) }
             )
         },


### PR DESCRIPTION
## Summary
Brings the app's bars onto the standard Material 3
`ScrollBehavior` APIs and fixes the bottom bar's "half-hidden peeking"
stuck state plus the scroll-time jank it caused.

## Top app bars: enterAlways on long-list tabs
- **Journal / Settings / SaferUse**: `TopAppBarDefaults.enterAlwaysScrollBehavior()` — scrolling down collapses the bar
for maximum list space, any downward scroll brings it right back. Built-in slop + snap from M3, no custom gesture code.
- **Stats stays pinned**: its header holds the section TabRow + consumer switcher; a collapsing header causes
scroll-state jumps when switching tabs.
- **Search stays pinned**: collapsing the search field would add friction to re-focus it.
- MainScreen's bottom-bar `onPreScroll` top-of-list reveal is untouched; the tab Scaffolds chain the top-bar connection
after the existing `bottomBarNestedScroll()`.

## Bottom bar: no more half-hidden states
The previous scheme (`BottomAppBarDefaults.exitAlwaysScrollBehavior` + `heightOffsetLimit` set from `onSizeChanged` +
`AnimatedVisibility`) could strand the bar mid-way:

- During the show/hide animation, measured height shrank, which re-wrote `heightOffsetLimit`, which clamped
`heightOffset` — the limit chased the animation and the bar froze at e.g. −40dp, leaving five icons peeking.
- M3's `settleAppBar` doesn't reliably snap to an edge from a slow-drag release (zero fling velocity), and the
animation/limit interaction could cancel the settle coroutine entirely.

New self-contained scheme in `MainScreen`:
- **Fixed hide distance**: `80dp + WindowInsets.navigationBars.bottom`, computed once from density — never derived from
layout size, so the limit can't shrink mid-flight and the bar sinks fully below the screen edge including the gesture
area.
- **Mandatory snap**: `onPostFling` always animates to fully shown (0) or fully hidden (−total) at 200ms; intermediate
resting states no longer exist at any release velocity.
- **One translation path**: show/hide (tab switch, keyboard) and scroll-hide both drive a single
`graphicsLayer.translationY` — pure draw-phase, no `AnimatedVisibility` size fights.

## Perf: zero recomposition while scrolling
Profiling showed every scroll frame recomposed MainScreen's entire branch and re-measured all four tab lists, because
the scroll offset was a `mutableFloatStateOf` read in composition (`visibleBarPx` → CompositionLocal →
`LazyColumn.contentPadding` / FAB padding).

- Scroll offset now lives in a plain `floatArray` held by `remember`; its only readers are the `NestedScrollConnection`
callbacks and the bar's `graphicsLayer` lambda — both outside composition.
- Content padding is static per show/hide state (full bar height or 0); it no longer tracks the mid-drag offset.
- Scrolling the bar away now costs zero recompositions and zero re-measures — draw-phase only.

## Test plan
- [x] `compileDebugKotlin` + `assembleDebug` pass
- [x] Journal/Settings/SaferUse: scroll down → top bar collapses; scroll up (even at list top) → returns instantly
- [x] Stats/Search: top bars stay pinned
- [x] Bottom bar: slow-drag to ~50% and release → snaps fully shown or fully hidden (no peeking icons)
- [x] Bottom bar sinks fully below the screen edge (gesture-nav area included)
- [x] Scroll a long list → bottom bar hides with no jank; list items do not re-layout per frame
- [ ] Switch tab / open keyboard → bar hides smoothly and offset resets