### PR TITLE
feat(settings): add toggle to keep the bottom menu visible while scrolling

### DIFF
--- a/app/src/main/assets/lang/en_us.json
+++ b/app/src/main/assets/lang/en_us.json
@@ -33,6 +33,8 @@
   "settings_use_24_hour_clock": "Use 24-hour time",
   "settings_stats_by_ingestion_time": "Stats by ingestion time",
   "settings_stats_by_ingestion_time_description": "Place each ingestion on the day it happened instead of grouping a whole experience into its first day",
+  "settings_keep_bottom_bar_visible": "Keep bottom menu visible",
+  "settings_keep_bottom_bar_visible_description": "When enabled, the bottom menu stays fixed while you scroll instead of hiding",
   "settings_app_data": "App data",
   "settings_export_file": "Export file",
   "settings_export_title": "Export?",

--- a/app/src/main/assets/lang/zh_cn.json
+++ b/app/src/main/assets/lang/zh_cn.json
@@ -33,6 +33,8 @@
   "settings_use_24_hour_clock": "使用24小时制",
   "settings_stats_by_ingestion_time": "按摄入时间统计",
   "settings_stats_by_ingestion_time_description": "每次摄入按真实发生日期计入，而不是把整段体验算在第一天",
+  "settings_keep_bottom_bar_visible": "保持底部菜单常显",
+  "settings_keep_bottom_bar_visible_description": "开启后，滚动时底部菜单固定不动，不再自动隐藏",
   "settings_app_data": "应用数据",
   "settings_export_file": "导出文件",
   "settings_export_title": "导出？",

--- a/app/src/main/assets/lang/zh_tw.json
+++ b/app/src/main/assets/lang/zh_tw.json
@@ -33,6 +33,8 @@
   "settings_use_24_hour_clock": "使用24小時制",
   "settings_stats_by_ingestion_time": "依攝入時間統計",
   "settings_stats_by_ingestion_time_description": "每次攝入依真實發生日期計入，而不是把整段體驗算在第一天",
+  "settings_keep_bottom_bar_visible": "保持底部選單常顯",
+  "settings_keep_bottom_bar_visible_description": "開啟後，捲動時底部選單固定不動，不再自動隱藏",
   "settings_app_data": "應用程式資料",
   "settings_export_file": "匯出檔案",
   "settings_export_title": "匯出？",

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreen.kt
@@ -99,6 +99,7 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         I18n.setPreferredLanguageKey(selectedLanguageKey)
     }
     val isAccepted = viewModel.isAcceptedFlow.collectAsState().value
+    val isBottomBarPinned = viewModel.isBottomBarPinnedFlow.collectAsState().value
 
     // Notification taps can steer the app to a target screen (quick note / time capsule).
     // Tracked above the gate so the intent survives the accept/lock screens and is
@@ -163,48 +164,57 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
         val isKeyboardOpenNow = isKeyboardOpen().value
         val isOnMainTabRoot = isMainTabRootRoute(currentDestination?.route)
         val isBottomBarShown = isOnMainTabRoot && !isKeyboardOpenNow
-
         // Official Material3 hide-on-scroll connection, plus onPreScroll so an
         // upward swipe at the list top (consumed.y == 0) still reveals the bar.
+        // When the user pins the bar (issue #144) no connection is provided at
+        // all: lists scroll normally and the bar never moves.
         val bottomBarScrollBehavior = BottomAppBarDefaults.exitAlwaysScrollBehavior(
             canScroll = { isOnMainTabRoot && !isKeyboardOpenNow }
         )
-        val nestedScrollConnection = remember(bottomBarScrollBehavior) {
-            val official = bottomBarScrollBehavior.nestedScrollConnection
-            object : NestedScrollConnection {
-                override fun onPreScroll(
-                    available: Offset,
-                    source: NestedScrollSource
-                ): Offset {
-                    if (available.y > 0f &&
-                        bottomBarScrollBehavior.state.heightOffset < 0f
-                    ) {
-                        val state = bottomBarScrollBehavior.state
-                        val next = (state.heightOffset + available.y)
-                            .coerceIn(state.heightOffsetLimit, 0f)
-                        val consumedY = next - state.heightOffset
-                        state.heightOffset = next
-                        return Offset(0f, consumedY)
+        val nestedScrollConnection = if (isBottomBarPinned) {
+            null
+        } else {
+            remember(bottomBarScrollBehavior) {
+                val official = bottomBarScrollBehavior.nestedScrollConnection
+                object : NestedScrollConnection {
+                    override fun onPreScroll(
+                        available: Offset,
+                        source: NestedScrollSource
+                    ): Offset {
+                        if (available.y > 0f &&
+                            bottomBarScrollBehavior.state.heightOffset < 0f
+                        ) {
+                            val state = bottomBarScrollBehavior.state
+                            val next = (state.heightOffset + available.y)
+                                .coerceIn(state.heightOffsetLimit, 0f)
+                            val consumedY = next - state.heightOffset
+                            state.heightOffset = next
+                            return Offset(0f, consumedY)
+                        }
+                        return Offset.Zero
                     }
-                    return Offset.Zero
-                }
 
-                override fun onPostScroll(
-                    consumed: Offset,
-                    available: Offset,
-                    source: NestedScrollSource
-                ): Offset = official.onPostScroll(consumed, available, source)
+                    override fun onPostScroll(
+                        consumed: Offset,
+                        available: Offset,
+                        source: NestedScrollSource
+                    ): Offset = official.onPostScroll(consumed, available, source)
+                }
             }
         }
-        LaunchedEffect(isOnMainTabRoot, isKeyboardOpenNow) {
-            if (!isOnMainTabRoot || isKeyboardOpenNow) {
+        LaunchedEffect(isOnMainTabRoot, isKeyboardOpenNow, isBottomBarPinned) {
+            if (!isOnMainTabRoot || isKeyboardOpenNow || isBottomBarPinned) {
                 bottomBarScrollBehavior.state.heightOffset = 0f
             }
         }
 
         Box(modifier = Modifier.fillMaxSize()) {
             val barHeightPx = remember { mutableIntStateOf(0) }
-            val heightOffset = bottomBarScrollBehavior.state.heightOffset
+            val heightOffset = if (isBottomBarPinned) {
+                0f
+            } else {
+                bottomBarScrollBehavior.state.heightOffset
+            }
             val visibleBarPx = if (isBottomBarShown) {
                 (barHeightPx.intValue + heightOffset.toInt()).coerceAtLeast(0)
             } else {
@@ -244,7 +254,11 @@ fun MainScreen(viewModel: MainScreenViewModel = hiltViewModel()) {
                         .offset {
                             IntOffset(
                                 x = 0,
-                                y = -bottomBarScrollBehavior.state.heightOffset.toInt()
+                                y = if (isBottomBarPinned) {
+                                    0
+                                } else {
+                                    -bottomBarScrollBehavior.state.heightOffset.toInt()
+                                }
                             )
                         }
                 ) {

--- a/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreenViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/main/MainScreenViewModel.kt
@@ -66,6 +66,13 @@ class MainScreenViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000)
     )
 
+    val isBottomBarPinnedFlow: StateFlow<Boolean> =
+        userPreferences.isBottomBarPinnedFlow.stateIn(
+            initialValue = false,
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000)
+        )
+
     // Unlock state lives for the process lifetime: once authenticated, the app stays
     // unlocked until it is killed. Reset when the lock is disabled by the user.
     private val _isUnlocked = MutableStateFlow(false)

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/PreferencesScreen.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/PreferencesScreen.kt
@@ -76,6 +76,8 @@ fun PreferencesScreen(
         saveOpenLinkInBrowser = viewModel::saveOpenLinkInBrowser,
         isTimelineHidden = viewModel.isTimelineHiddenFlow.collectAsState().value,
         saveIsTimelineHidden = viewModel::saveIsTimelineHidden,
+        isBottomBarPinned = viewModel.isBottomBarPinnedFlow.collectAsState().value,
+        saveIsBottomBarPinned = viewModel::saveIsBottomBarPinned,
         areSubstanceHeightsIndependent =
             viewModel.areSubstanceHeightsIndependentFlow.collectAsState().value,
         saveAreSubstanceHeightsIndependent = viewModel::saveAreSubstanceHeightsIndependent,
@@ -109,6 +111,8 @@ fun PreferencesScreen(
     saveOpenLinkInBrowser: (Boolean) -> Unit,
     isTimelineHidden: Boolean,
     saveIsTimelineHidden: (Boolean) -> Unit,
+    isBottomBarPinned: Boolean,
+    saveIsBottomBarPinned: (Boolean) -> Unit,
     areSubstanceHeightsIndependent: Boolean,
     saveAreSubstanceHeightsIndependent: (Boolean) -> Unit,
     isMidnightCutoffEnabled: Boolean,
@@ -222,6 +226,13 @@ fun PreferencesScreen(
                     title = i18n("settings_hide_timeline"),
                     checked = isTimelineHidden,
                     onCheckedChange = saveIsTimelineHidden
+                )
+                HorizontalDivider()
+                PreferenceSwitchRow(
+                    title = i18n("settings_keep_bottom_bar_visible"),
+                    description = i18n("settings_keep_bottom_bar_visible_description"),
+                    checked = isBottomBarPinned,
+                    onCheckedChange = saveIsBottomBarPinned
                 )
                 HorizontalDivider()
                 IndependentHeightsRow(

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/SettingsViewModel.kt
@@ -66,6 +66,16 @@ class SettingsViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000)
     )
 
+    fun saveIsBottomBarPinned(value: Boolean) = viewModelScope.launch {
+        userPreferences.saveIsBottomBarPinned(value)
+    }
+
+    val isBottomBarPinnedFlow = userPreferences.isBottomBarPinnedFlow.stateIn(
+        initialValue = false,
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
+
     val areSubstanceHeightsIndependentFlow = userPreferences.areSubstanceHeightsIndependentFlow.stateIn(
         initialValue = false,
         scope = viewModelScope,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/tabs/settings/combinations/UserPreferences.kt
@@ -54,6 +54,7 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
         val KEY_APP_LOCK_ENABLED = booleanPreferencesKey("key_app_lock_enabled")
         val KEY_EFFECT_NOTIFICATION_ENABLED = booleanPreferencesKey("key_effect_notification_enabled")
         val KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT = booleanPreferencesKey("KEY_ARE_SUBSTANCE_HEIGHTS_INDEPENDENT")
+        val KEY_IS_BOTTOM_BAR_PINNED = booleanPreferencesKey("key_is_bottom_bar_pinned")
         val KEY_IS_TIMELINE_HIDDEN = booleanPreferencesKey("KEY_IS_TIMELINE_HIDDEN")
         val KEY_MIDNIGHT_CUTOFF_ENABLED = booleanPreferencesKey("key_midnight_cutoff_enabled")
         val KEY_USE_24_HOUR_CLOCK = booleanPreferencesKey("key_use_24_hour_clock")
@@ -180,6 +181,17 @@ class UserPreferences @Inject constructor(private val dataStore: DataStore<Prefe
     suspend fun saveIsTimelineHidden(value: Boolean) {
         dataStore.edit { preferences ->
             preferences[PreferencesKeys.KEY_IS_TIMELINE_HIDDEN] = value
+        }
+    }
+
+    val isBottomBarPinnedFlow: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.KEY_IS_BOTTOM_BAR_PINNED] ?: false
+        }
+
+    suspend fun saveIsBottomBarPinned(value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferencesKeys.KEY_IS_BOTTOM_BAR_PINNED] = value
         }
     }
 


### PR DESCRIPTION
Closes #144. Adds a "Keep bottom menu visible" switch in Preferences > UI (localized en/zh_cn/zh_tw). When enabled the main-tab bottom bar never hides:

- no nested-scroll connection is provided to tab content, so lists scroll without driving the bar
- heightOffset is forced to 0 and the bar offset/inset reflect the full height immediately when the toggle changes
- default remains the current hide-on-scroll behavior