### PR TITLE
fix(widgets): drive stats widget refresh from JournalDataEvents

### DIFF
--- a/app/src/main/java/com/isaakhanimann/journal/MainActivity.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/MainActivity.kt
@@ -18,9 +18,6 @@
 
 package com.isaakhanimann.journal
 
-import android.appwidget.AppWidgetManager
-import android.content.ComponentName
-import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import androidx.activity.compose.setContent
@@ -32,8 +29,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.isaakhanimann.journal.ui.main.MainScreen
 import com.isaakhanimann.journal.ui.theme.JournalTheme
-import com.isaakhanimann.journal.ui.widgets.StatsWidgetProvider
+import com.isaakhanimann.journal.ui.widgets.StatsWidgetUpdater
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : FragmentActivity() {
@@ -71,15 +69,16 @@ class MainActivity : FragmentActivity() {
             root,
             force = false
         )
-        // Keep the stats widget in sync after any journal change made in-app.
-        val ids = AppWidgetManager.getInstance(this).getAppWidgetIds(
-            ComponentName(this, StatsWidgetProvider::class.java)
-        )
-        if (ids.isNotEmpty()) {
-            sendBroadcast(Intent(this, StatsWidgetProvider::class.java).apply {
-                action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
-            })
+        // Keep the stats widget in sync after any journal change made while
+        // the app was closed or in the background. The updater computes on
+        // Dispatchers.Default; only the RemoteViews push runs here.
+        val app = application as com.isaakhanimann.journal.di.JournalApplication
+        app.applicationScope.launch {
+            try {
+                StatsWidgetUpdater.refreshAll(this@MainActivity, app.experienceRepository)
+            } catch (_: Exception) {
+                // Widget refresh must never crash the app process.
+            }
         }
     }
 }

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceDao.kt
@@ -39,6 +39,7 @@ import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithI
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsAndCompanions
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsCompanionsAndRatings
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsTimedNotesAndRatings
+import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWindowCounts
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithCompanion
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithCompanionAndCustomUnit
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithExperienceAndCustomUnit
@@ -200,6 +201,20 @@ interface ExperienceDao {
         fromInstant: Instant,
         toInstant: Instant
     ): List<IngestionWithCompanion>
+
+    /** Aggregates the three widget counts in SQL; no row materialization. */
+    @Query(
+        "SELECT COUNT(*) AS ingestionCount," +
+            " COUNT(DISTINCT experienceId) AS experienceCount," +
+            " COUNT(DISTINCT substanceName) AS substanceCount" +
+            " FROM ingestion WHERE time >= :fromInstant AND time < :toInstant" +
+            " AND (:substanceName IS NULL OR substanceName = :substanceName)"
+    )
+    suspend fun getIngestionWindowCounts(
+        fromInstant: Instant,
+        toInstant: Instant,
+        substanceName: String?
+    ): IngestionWindowCounts
 
     @Transaction
     @Query("SELECT * FROM ingestion WHERE id =:id")

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/ExperienceRepository.kt
@@ -30,6 +30,7 @@ import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithI
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsAndCompanions
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsCompanionsAndRatings
 import com.isaakhanimann.journal.data.room.experiences.relations.ExperienceWithIngestionsTimedNotesAndRatings
+import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWindowCounts
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithCompanion
 import com.isaakhanimann.journal.data.room.experiences.relations.IngestionWithExperienceAndCustomUnit
 import com.isaakhanimann.journal.ui.tabs.settings.JournalExport
@@ -62,13 +63,15 @@ class ExperienceRepository @Inject constructor(private val experienceDao: Experi
         ingestion,
         experience,
         substanceCompanion
-    )
+    ).also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun insertEverything(journalExport: JournalExport) =
         experienceDao.insertEverything(journalExport)
+            .also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun replaceEverything(journalExport: JournalExport) =
         experienceDao.replaceEverything(journalExport)
+            .also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun insertIngestionAndCompanion(
         ingestion: Ingestion,
@@ -76,9 +79,10 @@ class ExperienceRepository @Inject constructor(private val experienceDao: Experi
     ) = experienceDao.insertIngestionAndCompanion(
         ingestion,
         substanceCompanion
-    )
+    ).also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun deleteEverything() = experienceDao.deleteEverything()
+        .also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun delete(ingestion: Ingestion) = experienceDao.delete(ingestion).also { JournalDataEvents.notifyJournalChanged() }
     suspend fun delete(customUnit: CustomUnit) = experienceDao.delete(customUnit).also { JournalDataEvents.notifyJournalChanged() }
@@ -98,6 +102,7 @@ class ExperienceRepository @Inject constructor(private val experienceDao: Experi
 
     suspend fun delete(experienceWithIngestions: ExperienceWithIngestions) =
         experienceDao.deleteExperienceWithIngestions(experienceWithIngestions)
+            .also { JournalDataEvents.notifyJournalChanged() }
 
     suspend fun deleteUnusedSubstanceCompanions() =
         experienceDao.deleteUnusedSubstanceCompanions()
@@ -149,6 +154,13 @@ class ExperienceRepository @Inject constructor(private val experienceDao: Experi
         toInstant: Instant
     ): List<IngestionWithCompanion> =
         experienceDao.getIngestionsWithCompanions(fromInstant, toInstant)
+
+    suspend fun getIngestionWindowCounts(
+        fromInstant: Instant,
+        toInstant: Instant,
+        substanceName: String?
+    ): IngestionWindowCounts =
+        experienceDao.getIngestionWindowCounts(fromInstant, toInstant, substanceName)
 
     fun getSortedLastUsedSubstanceNamesFlow(limit: Int): Flow<List<String>> =
         experienceDao.getSortedLastUsedSubstanceNamesFlow(limit).flowOn(Dispatchers.IO).conflate()

--- a/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/relations/IngestionWithCompanion.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/data/room/experiences/relations/IngestionWithCompanion.kt
@@ -33,3 +33,10 @@ data class IngestionWithCompanion(
     )
     var substanceCompanion: SubstanceCompanion?
 )
+
+/** Counts one stats widget renders, computed entirely in SQL. */
+data class IngestionWindowCounts(
+    val ingestionCount: Int,
+    val experienceCount: Int,
+    val substanceCount: Int
+)

--- a/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/di/JournalApplication.kt
@@ -71,8 +71,8 @@ class JournalApplication : Application(), Configuration.Provider {
         }
         applicationScope.launch {
             // Keep desktop widgets in sync: an initial pass, then re-render
-            // whenever the ingestion table changes (insert/edit/delete) or the
-            // app language changes (widget labels are localized), so the desktop
+            // whenever journal data changes (JournalDataEvents) or the app
+            // language changes (widget labels are localized), so the desktop
             // never waits for the hourly updatePeriod.
             com.isaakhanimann.journal.ui.widgets.StatsWidgetUpdater.observeDataChanges(
                 this@JournalApplication,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetConfigActivity.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetConfigActivity.kt
@@ -77,21 +77,15 @@ class StatsWidgetConfigActivity : ComponentActivity() {
                                     appWidgetId,
                                     StatsWidgetConfig(substanceName, days)
                                 )
-                                val manager =
-                                    AppWidgetManager.getInstance(this@StatsWidgetConfigActivity)
-                                lifecycleScope.launch {
-                                    StatsWidgetData.refresh(
-                                        this@StatsWidgetConfigActivity,
-                                        appWidgetId,
-                                        app.experienceRepository
-                                    )
-                                    manager.updateAppWidget(
-                                        appWidgetId,
-                                        StatsWidgetProvider.render(
+                                app.applicationScope.launch {
+                                    try {
+                                        StatsWidgetUpdater.refreshAll(
                                             this@StatsWidgetConfigActivity,
-                                            appWidgetId
+                                            app.experienceRepository
                                         )
-                                    )
+                                    } catch (_: Exception) {
+                                        // Widget refresh must never crash the app process.
+                                    }
                                 }
                                 setResult(
                                     Activity.RESULT_OK,

--- a/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetData.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetData.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private const val PREFS_NAME = "widget_stats"
 private const val KEY_PREFIX = "summary_"
@@ -64,32 +66,31 @@ object StatsWidgetData {
             }
         }.apply()
     }
+
+    /**
+     * Recomputes the summary for one widget and stores it. All work runs on
+     * Dispatchers.Default: callers may be on the main thread (application
+     * scope, activity onResume), and the SQL aggregate does the counting so
+     * no ingestion rows are materialized in Kotlin.
+     */
     suspend fun refresh(
         context: Context,
         appWidgetId: Int,
         experienceRepository: ExperienceRepository
-    ) {
+    ) = withContext(Dispatchers.Default) {
         val config = readConfig(context, appWidgetId)
-        val from = Instant.now().minus(config.days.toLong(), ChronoUnit.DAYS)
-        val ingestions =
-            experienceRepository.getIngestionsWithCompanions(from, Instant.now())
-        val filtered = if (config.substanceName == null) {
-            ingestions
-        } else {
-            ingestions.filter { it.ingestion.substanceName == config.substanceName }
-        }
-        val summary = StatsWidgetSummary(
-            substanceName = config.substanceName,
-            days = config.days,
-            ingestionCount = filtered.size,
-            experienceCount = filtered.map { it.ingestion.experienceId }.distinct().size,
-            substanceCount = filtered.map { it.ingestion.substanceName }.distinct().size
+        val to = Instant.now()
+        val from = to.minus(config.days.toLong(), ChronoUnit.DAYS)
+        val counts = experienceRepository.getIngestionWindowCounts(
+            from,
+            to,
+            config.substanceName
         )
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .edit()
-            .putInt(configKey(appWidgetId, "sum_ingestions"), summary.ingestionCount)
-            .putInt(configKey(appWidgetId, "sum_experiences"), summary.experienceCount)
-            .putInt(configKey(appWidgetId, "sum_substances"), summary.substanceCount)
+            .putInt(configKey(appWidgetId, "sum_ingestions"), counts.ingestionCount)
+            .putInt(configKey(appWidgetId, "sum_experiences"), counts.experienceCount)
+            .putInt(configKey(appWidgetId, "sum_substances"), counts.substanceCount)
             .apply()
     }
 

--- a/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetUpdater.kt
+++ b/app/src/main/java/com/isaakhanimann/journal/ui/widgets/StatsWidgetUpdater.kt
@@ -4,31 +4,39 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import com.isaakhanimann.journal.data.room.experiences.ExperienceRepository
+import com.isaakhanimann.journal.data.room.experiences.JournalDataEvents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 
 /**
- * Pushes fresh summaries into every placed stats widget. Called on data
- * changes (ingestion table), app-language changes, and app start, so the
- * desktop never waits for the hourly updatePeriod.
+ * Pushes fresh summaries into every placed stats widget. Called on journal
+ * data changes (JournalDataEvents), app-language changes, and app start, so
+ * the desktop never waits for the hourly updatePeriod.
  */
 object StatsWidgetUpdater {
 
+    /**
+     * Refreshes every placed widget. Safe from the main thread: data reads
+     * and preference writes run on Dispatchers.Default, only the RemoteViews
+     * push touches the framework. No-op when no stats widget is placed.
+     */
     suspend fun refreshAll(context: Context, experienceRepository: ExperienceRepository) {
-        val manager = AppWidgetManager.getInstance(context)
+        val appContext = context.applicationContext
+        val manager = AppWidgetManager.getInstance(appContext)
         val ids = manager.getAppWidgetIds(
-            ComponentName(context, StatsWidgetProvider::class.java)
+            ComponentName(appContext, StatsWidgetProvider::class.java)
         )
+        if (ids.isEmpty()) return
         ids.forEach { id ->
-            StatsWidgetData.refresh(context, id, experienceRepository)
-            manager.updateAppWidget(id, StatsWidgetProvider.render(context, id))
+            StatsWidgetData.refresh(appContext, id, experienceRepository)
+            manager.updateAppWidget(id, StatsWidgetProvider.render(appContext, id))
         }
     }
 
     /**
-     * Recomputes whenever the ingestion table changes (insert/edit/delete).
+     * Recomputes whenever journal data changes (insert/edit/delete/import).
      * Debounced so an import or a burst of edits triggers one refresh.
      */
     @OptIn(FlowPreview::class)
@@ -38,7 +46,7 @@ object StatsWidgetUpdater {
         scope: CoroutineScope
     ) {
         scope.launch {
-            experienceRepository.getSortedIngestionsFlow()
+            JournalDataEvents.journalChangeSignal
                 .debounce(500)
                 .collect {
                     try {


### PR DESCRIPTION
Manual revert of a4fb7f25's live-sync mechanism, redone on the shared change signal instead of observing the full ingestion table.

- StatsWidgetUpdater.observeDataChanges collects JournalDataEvents.journalChangeSignal (debounced 500ms) rather than experienceRepository.getSortedIngestionsFlow(), so no Room query observer is held for the process lifetime.
- Emit the signal from the batch/transactional writes that previously relied on that Flow for widget coverage: insertEverything, replaceEverything, insertIngestionAndCompanion, insertIngestionExperienceAndCompanion, deleteEverything, delete(ExperienceWithIngestions).
- Count ingestion/experience/substance in one SQL aggregate (ExperienceDao.getIngestionWindowCounts) instead of materializing every IngestionWithCompanion and filtering/distinct-ing in Kotlin.
- Run StatsWidgetData.refresh on Dispatchers.Default so callers on the main thread (application scope, onResume) no longer do prefs writes and list processing on Main; refreshAll no-ops with no widget placed.
- MainActivity.onResume and the config save path reuse refreshAll instead of broadcasting APPWIDGET_UPDATE or re-rendering by hand; the config path launches on the application scope because the activity finishes immediately afterwards.